### PR TITLE
feat: 공통 응답 및 전역 에외 핸들러 구현

### DIFF
--- a/src/main/java/org/sopt/carena/global/api/code/ErrorResultCode.java
+++ b/src/main/java/org/sopt/carena/global/api/code/ErrorResultCode.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.global.api.code;
+
+/**
+ * 실패 응답 마커 인터페이스
+ */
+public interface ErrorResultCode extends ResultCode{
+}

--- a/src/main/java/org/sopt/carena/global/api/code/ResultCode.java
+++ b/src/main/java/org/sopt/carena/global/api/code/ResultCode.java
@@ -1,0 +1,9 @@
+package org.sopt.carena.global.api.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResultCode {
+	HttpStatus getStatus();
+
+	String getMessage();
+}

--- a/src/main/java/org/sopt/carena/global/api/code/SuccessResultCode.java
+++ b/src/main/java/org/sopt/carena/global/api/code/SuccessResultCode.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.global.api.code;
+
+/**
+ * 성공 응답 마커 인터페이스
+ */
+public interface SuccessResultCode extends ResultCode {
+}

--- a/src/main/java/org/sopt/carena/global/api/response/ApiResponse.java
+++ b/src/main/java/org/sopt/carena/global/api/response/ApiResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.carena.global.api.response;
+
+import org.sopt.carena.global.api.code.ErrorResultCode;
+import org.sopt.carena.global.api.code.SuccessResultCode;
+
+public interface ApiResponse {
+
+	int status();
+
+	String code();
+
+	String message();
+
+	static <T> SuccessResponse<T> success(SuccessResultCode successCode, T data) {
+		return SuccessResponse.of(successCode, data);
+	}
+
+	static <T> SuccessResponse<T> success(SuccessResultCode successCode) {
+		return SuccessResponse.of(successCode);
+	}
+
+	static FailureResponse failure(ErrorResultCode errorCode) {
+		return FailureResponse.of(errorCode);
+	}
+
+	static FailureResponse failure(ErrorResultCode errorCode, String message) {
+		return FailureResponse.of(errorCode, message);
+	}
+}

--- a/src/main/java/org/sopt/carena/global/api/response/FailureResponse.java
+++ b/src/main/java/org/sopt/carena/global/api/response/FailureResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.carena.global.api.response;
+
+import org.sopt.carena.global.api.code.ErrorResultCode;
+
+public record FailureResponse(
+		int status,
+		String code,
+		String message
+) implements ApiResponse {
+	public static FailureResponse of(ErrorResultCode errorCode) {
+		return new FailureResponse(
+				errorCode.getStatus().value(),
+				errorCode.toString(),
+				errorCode.getMessage());
+	}
+
+	public static FailureResponse of(ErrorResultCode errorCode, String message) {
+		return new FailureResponse(
+				errorCode.getStatus().value(),
+				errorCode.toString(),
+				message
+		);
+	}
+}

--- a/src/main/java/org/sopt/carena/global/api/response/SuccessResponse.java
+++ b/src/main/java/org/sopt/carena/global/api/response/SuccessResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.carena.global.api.response;
+
+import org.sopt.carena.global.api.code.SuccessResultCode;
+
+public record SuccessResponse<T>(
+		int status,
+		String code,
+		String message,
+		T data
+) {
+	public static <T> SuccessResponse<T> of(SuccessResultCode successCode, T data) {
+		return new SuccessResponse<>(
+				successCode.getStatus().value(),
+				successCode.toString(),
+				successCode.getMessage(), data);
+	}
+
+	public static <T> SuccessResponse<T> of(SuccessResultCode successCode) {
+		return new SuccessResponse<>(
+				successCode.getStatus().value(),
+				successCode.toString(),
+				successCode.getMessage(), null);
+	}
+}

--- a/src/main/java/org/sopt/carena/global/exception/BaseException.java
+++ b/src/main/java/org/sopt/carena/global/exception/BaseException.java
@@ -1,0 +1,15 @@
+package org.sopt.carena.global.exception;
+
+import org.sopt.carena.global.api.code.ErrorResultCode;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+	private final ErrorResultCode errorResultCode;
+
+	protected BaseException(ErrorResultCode errorResultCode) {
+		super(errorResultCode.getMessage());
+		this.errorResultCode = errorResultCode;
+	}
+}

--- a/src/main/java/org/sopt/carena/global/exception/code/ErrorCode.java
+++ b/src/main/java/org/sopt/carena/global/exception/code/ErrorCode.java
@@ -1,0 +1,23 @@
+package org.sopt.carena.global.exception.code;
+
+import org.sopt.carena.global.api.code.ErrorResultCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode implements ErrorResultCode {
+	// 400
+	INVALID_REQUEST_MESSAGE(HttpStatus.BAD_REQUEST, "요청 데이터의 입력값이 올바르지 않습니다."),
+
+	// 404
+	INVALID_ENDPOINT(HttpStatus.NOT_FOUND, "해당 엔드포인트의 요청을 처리할 수 없습니다."),
+
+	// 500
+	UNDEFINED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생하였습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/sopt/carena/global/exception/handler/BaseExceptionHandler.java
+++ b/src/main/java/org/sopt/carena/global/exception/handler/BaseExceptionHandler.java
@@ -1,0 +1,12 @@
+package org.sopt.carena.global.exception.handler;
+
+import org.sopt.carena.global.api.code.ErrorResultCode;
+import org.sopt.carena.global.api.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+
+public abstract class BaseExceptionHandler {
+	protected final ResponseEntity<ApiResponse> buildErrorResponse(ErrorResultCode errorResultCode) {
+		return ResponseEntity.status(errorResultCode.getStatus())
+				.body(ApiResponse.failure(errorResultCode));
+	}
+}

--- a/src/main/java/org/sopt/carena/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/carena/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package org.sopt.carena.global.exception.handler;
+
+import org.sopt.carena.global.api.response.ApiResponse;
+import org.sopt.carena.global.exception.BaseException;
+import org.sopt.carena.global.exception.code.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends BaseExceptionHandler {
+
+	@ExceptionHandler(BaseException.class)
+	protected ResponseEntity<ApiResponse> handleBaseException(BaseException e) {
+		return buildErrorResponse(e.getErrorResultCode());
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	protected ResponseEntity<ApiResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+		return buildErrorResponse(ErrorCode.INVALID_REQUEST_MESSAGE);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	protected ResponseEntity<ApiResponse> handleMethodArgumentTypeMismatchException(
+			MethodArgumentTypeMismatchException e) {
+		return buildErrorResponse(ErrorCode.INVALID_REQUEST_MESSAGE);
+	}
+
+	@ExceptionHandler(NoHandlerFoundException.class)
+	protected ResponseEntity<ApiResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+		return buildErrorResponse(ErrorCode.INVALID_ENDPOINT);
+	}
+
+	@ExceptionHandler(Exception.class)
+	protected ResponseEntity<ApiResponse> handleException(Exception e) {
+		// e.printStackTrace();
+		return buildErrorResponse(ErrorCode.UNDEFINED_ERROR);
+	}
+}


### PR DESCRIPTION
## **🚀 Related issue**

closes #1 

## **#️⃣ Summary**

- 성공 응답과 실패 응답에 대한 공통 응답 구조를 설정합니다.
- 응답 생성에 필요한 상태 코드 및 상태 메시지를 관리하는 enum의 인터페이스를 정의합니다.
- 예외 처리를 위한 핸들러 및 예외 클래스를 구현합니다.


## **🎯 Work Description**

- [x] 공통 응답 구조를 설정 및 구현
- [x] 성공 응답에 대한 상태코드와 메시지 관리 enum 인터페이스 설정
- [x] 에러 응답에 대한 상태코드와 메시지 관리 enum 인터페이스 설정
- [x] 기본 예외 클래스 구현
- [x] 전역 예외 핸들러 구현


## **👍 동작 확인**

- 성공 응답 테스트 결과
  <img width="748" height="448" alt="스크린샷 2026-01-04 오후 2 04 37" src="https://github.com/user-attachments/assets/b74faea2-3ac7-474b-a681-39a36802133f" />

- 실패 응답 테스트 결과
  <img width="744" height="435" alt="스크린샷 2026-01-04 오후 2 06 42" src="https://github.com/user-attachments/assets/2101818e-c9e6-4478-9c1e-a3a0981d7760" />

- 예외 처리 응답 테스트 결과
  <img width="748" height="435" alt="스크린샷 2026-01-04 오후 2 07 08" src="https://github.com/user-attachments/assets/16316015-0333-4da2-b8f2-e89ff25e184c" />


## **💬 To Reviewers**

- 공통 응답의 경우 `ApiResponse`인터페이스를 상속하는 `SuccessResponse`레코드와 `FailureResponse`로 분리하였습니다.
  - 레코드를 분리한 이유는 요청의 성공이나 실패에 따른 `T data`값의 유무를 나누어 관리하기 위해서 입니다.
  - `@JsonInclude(JsonInclude.Include.NON_NULL)`를 통해 `data`가 없는 경우 직렬화 대상에서 제외할 수 있지만 성공 응답의 데이터 유무에 따라 요청 성공 시에 발생하는 응답 구조의 일관성이 깨지는 경우가 발생하여 분리하였습니다.
  - `ApiResponse` 인터페이스의 메서드를 호출하여 응답 구조가 생성되지만, `controller` 및 `docs`에서 선언된 메서드의 반환값은 `SuccessResponse<T>` 또는 `FailureResponse`로 설정해야 스웨거 오류가 발생하지 않습니다.
- 상태 코드와 메시지를 관리하는 enum의 경우 현재 인터페이스와 마커 인터페이스만 구현되었습니다.
  - 각 도메인에 따라 내용이 달라지므로 도메인의 하위 패키지에 만들어서 도메인 별로 관리하는 것이 좋을 것 같다고 생각합니다.
  - 예외 클래스도 같은 이유로 현재 `BaseException` 추상클래스만 구현되었습니다.