### PR TITLE
fix: 로그인 후 리다이렉트시 엑세스 토큰 전달 오류 해결

### DIFF
--- a/src/main/java/org/sopt/carena/global/config/security/util/PublicEndpoint.java
+++ b/src/main/java/org/sopt/carena/global/config/security/util/PublicEndpoint.java
@@ -26,7 +26,8 @@ public enum PublicEndpoint {
     SWAGGER_UI("/swagger-ui/**", HttpMethod.GET),
     API_DOCS("/v3/api-docs/**", HttpMethod.GET),
     API_DOCS_V1("/api-docs/**", HttpMethod.GET),
-    WEBJARS("/webjars/**", HttpMethod.GET);
+    WEBJARS("/webjars/**", HttpMethod.GET),
+    GENERATED_TOKEN("/api/v1/member/tokens", HttpMethod.POST);
 
     private final String pattern;
     private final HttpMethod method;

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/code/MemberSuccessCode.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/code/MemberSuccessCode.java
@@ -11,7 +11,8 @@ public enum MemberSuccessCode implements SuccessResultCode {
 
     SIGNUP_SUCCESS(HttpStatus.OK, "회원가입이 완료되었습니다."),
     TOKEN_REFRESHED(HttpStatus.OK, "새 엑세스 토큰이 발급되었습니다."),
-    MEMBER_IFNO(HttpStatus.OK,"사용자 정보가 조회되었습니다.");
+    MEMBER_IFNO(HttpStatus.OK,"사용자 정보가 조회되었습니다."),
+    TOKEN_GENERATED(HttpStatus.OK,"엑세스토큰 및 리프레시토큰이 발급되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberApiDocs.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberApiDocs.java
@@ -1,31 +1,20 @@
 package org.sopt.carena.member.adapter.in.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import org.sopt.carena.global.api.response.SuccessResponse;
 import org.sopt.carena.member.adapter.in.web.dto.request.SignUpRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 
 @Tag(name = "멤버 관리",description = "회원가입, 토큰, 조회 관련 API")
 public interface MemberApiDocs {
     @Operation(summary = "회원가입" ,description = "회원가입을 진행합니다.")
-    ResponseEntity<SuccessResponse<Void>> signup(
-            @CookieValue(name = "tempToken") final String tempToken,
-            @RequestBody @Valid final SignUpRequest request,
-            HttpServletResponse response);
+    ResponseEntity<SuccessResponse<Void>> signup(String tempToken, SignUpRequest request, HttpServletResponse response);
 
     @Operation(summary = "토큰 재발급" ,description = "만료된 엑세스 토큰을 재발급합니다.")
-    ResponseEntity<SuccessResponse<Void>> refreshToken(
-            @CookieValue(name = "refreshToken") final String refreshToken,
-            HttpServletResponse response);
+    ResponseEntity<SuccessResponse<Void>> refreshToken(String refreshToken, HttpServletResponse response);
 
     @Operation(summary = "토큰 발급", description = "로그인 성공 후 해당 api를 이용하여 엑세스 및 리프레시 토큰을 발급받습니다.")
-    ResponseEntity<SuccessResponse<Void>> afterLogin(
-            @CookieValue(name="oneTimeToken") final String oneTimeToken,
-            HttpServletResponse response);
-
+    ResponseEntity<SuccessResponse<Void>> afterLogin(String oneTimeToken, HttpServletResponse response);
 }

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberApiDocs.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberApiDocs.java
@@ -23,4 +23,9 @@ public interface MemberApiDocs {
             @CookieValue(name = "refreshToken") final String refreshToken,
             HttpServletResponse response);
 
+    @Operation(summary = "토큰 발급", description = "로그인 성공 후 해당 api를 이용하여 엑세스 및 리프레시 토큰을 발급받습니다.")
+    ResponseEntity<SuccessResponse<Void>> afterLogin(
+            @CookieValue(name="oneTimeToken") final String oneTimeToken,
+            HttpServletResponse response);
+
 }

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
@@ -12,7 +12,9 @@ import org.sopt.carena.member.adapter.in.web.controller.util.HeaderUtil;
 import org.sopt.carena.member.adapter.in.web.dto.request.SignUpRequest;
 import org.sopt.carena.member.adapter.in.web.code.MemberSuccessCode;
 import org.sopt.carena.member.application.dto.command.SignUpCommand;
+import org.sopt.carena.member.application.dto.view.TokenGeneratedView;
 import org.sopt.carena.member.application.dto.view.TokenRefreshView;
+import org.sopt.carena.member.application.port.in.GenerateTokenUseCase;
 import org.sopt.carena.member.application.port.in.RefreshTokenUseCase;
 import org.sopt.carena.member.application.port.in.SignupUseCase;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +28,7 @@ public class MemberController implements MemberApiDocs{
 
     private final SignupUseCase signupUseCase;
     private final RefreshTokenUseCase refreshTokenUseCase;
+    private final GenerateTokenUseCase generateTokenUseCase;
 
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<Void>> signup(
@@ -52,5 +55,17 @@ public class MemberController implements MemberApiDocs{
         CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
         return ResponseEntity.status(MemberSuccessCode.TOKEN_REFRESHED.getStatus())
                         .body(ApiResponse.success(MemberSuccessCode.TOKEN_REFRESHED));
+    }
+
+    @PostMapping("/tokens")
+    public ResponseEntity<SuccessResponse<Void>> afterLogin(
+            @CookieValue(name="oneTimeToken") final String oneTimeToken,
+            HttpServletResponse response
+    ) {
+        TokenGeneratedView result=generateTokenUseCase.generateToken(oneTimeToken);
+        HeaderUtil.setAuthorizationHeader(response, result.accessToken());
+        CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
+        return ResponseEntity.status(MemberSuccessCode.TOKEN_GENERATED.getStatus())
+                .body(ApiResponse.success(MemberSuccessCode.TOKEN_GENERATED));
     }
 }

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
@@ -13,7 +13,6 @@ import org.sopt.carena.member.adapter.in.web.dto.request.SignUpRequest;
 import org.sopt.carena.member.adapter.in.web.code.MemberSuccessCode;
 import org.sopt.carena.member.application.dto.command.SignUpCommand;
 import org.sopt.carena.member.application.dto.view.TokenGeneratedView;
-import org.sopt.carena.member.application.dto.view.TokenRefreshView;
 import org.sopt.carena.member.application.port.in.GenerateTokenUseCase;
 import org.sopt.carena.member.application.port.in.RefreshTokenUseCase;
 import org.sopt.carena.member.application.port.in.SignupUseCase;
@@ -50,7 +49,7 @@ public class MemberController implements MemberApiDocs{
             @CookieValue(name = "refreshToken") final String refreshToken,
             HttpServletResponse response
     ) {
-        TokenRefreshView result = refreshTokenUseCase.refreshAccessToken(refreshToken);
+        TokenGeneratedView result = refreshTokenUseCase.refreshAccessToken(refreshToken);
         HeaderUtil.setAuthorizationHeader(response, result.accessToken());
         CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
         return ResponseEntity.status(MemberSuccessCode.TOKEN_REFRESHED.getStatus())

--- a/src/main/java/org/sopt/carena/member/adapter/out/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/org/sopt/carena/member/adapter/out/oauth/handler/OAuth2SuccessHandler.java
@@ -70,9 +70,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             LoginSuccessView loginResult
     ) throws IOException {
         log.info("기존 회원 - 메인 페이지로 리다이렉트");
-        // JWT 쿠키에 저장
-        response.setHeader("Authorization", "Bearer " + loginResult.accessToken());
-        addCookie(response, "refreshToken", loginResult.refreshToken(), 1209600);
+        //response.setHeader("Authorization", "Bearer " + loginResult.accessToken());
+        addCookie(response, "oneTimeToken", loginResult.oneTimeToken(), 1209600);
         // 메인 페이지로 리다이렉트
         String redirectUrl = frontendUrl + "/home";
         response.sendRedirect(redirectUrl);

--- a/src/main/java/org/sopt/carena/member/application/dto/view/LoginSuccessView.java
+++ b/src/main/java/org/sopt/carena/member/application/dto/view/LoginSuccessView.java
@@ -1,15 +1,13 @@
 package org.sopt.carena.member.application.dto.view;
 
 public record LoginSuccessView(
-        String accessToken,
-        String refreshToken,
+        String oneTimeToken,
         MemberView member
 ) implements OAuth2LoginResult {
     public static LoginSuccessView of(
-            final String accessToken,
-            final String refreshToken,
+            final String oneTimeToken,
             final MemberView member
     ) {
-        return new LoginSuccessView(accessToken, refreshToken, member);
+        return new LoginSuccessView(oneTimeToken, member);
     }
 }

--- a/src/main/java/org/sopt/carena/member/application/dto/view/TokenGeneratedView.java
+++ b/src/main/java/org/sopt/carena/member/application/dto/view/TokenGeneratedView.java
@@ -1,0 +1,6 @@
+package org.sopt.carena.member.application.dto.view;
+
+public record TokenGeneratedView (
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/org/sopt/carena/member/application/dto/view/TokenRefreshView.java
+++ b/src/main/java/org/sopt/carena/member/application/dto/view/TokenRefreshView.java
@@ -1,6 +1,0 @@
-package org.sopt.carena.member.application.dto.view;
-
-public record TokenRefreshView(
-        String accessToken,
-        String refreshToken
-) {}

--- a/src/main/java/org/sopt/carena/member/application/port/in/GenerateTokenUseCase.java
+++ b/src/main/java/org/sopt/carena/member/application/port/in/GenerateTokenUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.member.application.port.in;
+
+import org.sopt.carena.member.application.dto.view.TokenGeneratedView;
+
+public interface GenerateTokenUseCase {
+    TokenGeneratedView generateToken(String oneTimeToken);
+}

--- a/src/main/java/org/sopt/carena/member/application/port/in/RefreshTokenUseCase.java
+++ b/src/main/java/org/sopt/carena/member/application/port/in/RefreshTokenUseCase.java
@@ -1,7 +1,7 @@
 package org.sopt.carena.member.application.port.in;
 
-import org.sopt.carena.member.application.dto.view.TokenRefreshView;
+import org.sopt.carena.member.application.dto.view.TokenGeneratedView;
 
 public interface RefreshTokenUseCase {
-    TokenRefreshView refreshAccessToken(String refreshToken);
+    TokenGeneratedView refreshAccessToken(String refreshToken);
 }

--- a/src/main/java/org/sopt/carena/member/application/service/GenerateTokenService.java
+++ b/src/main/java/org/sopt/carena/member/application/service/GenerateTokenService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class GenerateTokenService implements GenerateTokenUseCase {
 
     private final RefreshTokenStore refreshTokenStore;

--- a/src/main/java/org/sopt/carena/member/application/service/GenerateTokenService.java
+++ b/src/main/java/org/sopt/carena/member/application/service/GenerateTokenService.java
@@ -10,6 +10,7 @@ import org.sopt.carena.member.application.port.out.RefreshTokenStore;
 import org.sopt.carena.member.application.service.util.JwtTokenGenerator;
 import org.sopt.carena.member.domain.AuthType;
 import org.sopt.carena.member.domain.Member;
+import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
 import org.sopt.carena.member.exception.member.InvalidTempTokenException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +39,7 @@ public class GenerateTokenService implements GenerateTokenUseCase {
         String providerUserId = parts[1];
 
         Optional<Member> member = memberPersistencePort.findByAuthTypeAndProviderUserId(authType,providerUserId);
-        Long memberId = member.get().getId();
+        Long memberId = member.orElseThrow(MemberNotFoundException::new).getId();
         String AccessToken = jwtTokenGenerator.createAccessToken(memberId);
         String RefreshToken = jwtTokenGenerator.createRefreshToken(memberId);
 

--- a/src/main/java/org/sopt/carena/member/application/service/GenerateTokenService.java
+++ b/src/main/java/org/sopt/carena/member/application/service/GenerateTokenService.java
@@ -1,0 +1,49 @@
+package org.sopt.carena.member.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.carena.member.application.dto.view.TokenGeneratedView;
+import org.sopt.carena.member.application.port.in.GenerateTokenUseCase;
+import org.sopt.carena.member.application.port.out.JoinTokenStore;
+import org.sopt.carena.member.application.port.out.MemberPersistencePort;
+import org.sopt.carena.member.application.port.out.RefreshTokenStore;
+import org.sopt.carena.member.application.service.util.JwtTokenGenerator;
+import org.sopt.carena.member.domain.AuthType;
+import org.sopt.carena.member.domain.Member;
+import org.sopt.carena.member.exception.member.InvalidTempTokenException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GenerateTokenService implements GenerateTokenUseCase {
+
+    private final RefreshTokenStore refreshTokenStore;
+    private final JoinTokenStore joinTokenStore;
+    private final JwtTokenGenerator jwtTokenGenerator;
+    private final MemberPersistencePort memberPersistencePort;
+
+    @Override
+    public TokenGeneratedView generateToken(final String oneTimeToken) {
+
+        String inputMemberInfo = joinTokenStore.getAuthId(oneTimeToken)
+                .orElseThrow(InvalidTempTokenException::new);
+        log.info("oneTimeToken 검증 완료 - authId: {}", inputMemberInfo);
+        String[] parts = inputMemberInfo.split("\\|");
+        AuthType authType = AuthType.valueOf(parts[0]);
+        String providerUserId = parts[1];
+
+        Optional<Member> member = memberPersistencePort.findByAuthTypeAndProviderUserId(authType,providerUserId);
+        Long memberId = member.get().getId();
+        String AccessToken = jwtTokenGenerator.createAccessToken(memberId);
+        String RefreshToken = jwtTokenGenerator.createRefreshToken(memberId);
+
+        joinTokenStore.delete(oneTimeToken);
+        refreshTokenStore.save(memberId, RefreshToken);
+        return new TokenGeneratedView(AccessToken,RefreshToken);
+    }
+}

--- a/src/main/java/org/sopt/carena/member/application/service/OAuth2LoginService.java
+++ b/src/main/java/org/sopt/carena/member/application/service/OAuth2LoginService.java
@@ -6,8 +6,6 @@ import org.sopt.carena.member.application.dto.view.*;
 import org.sopt.carena.member.application.port.in.OAuth2LoginUseCase;
 import org.sopt.carena.member.application.port.out.JoinTokenStore;
 import org.sopt.carena.member.application.port.out.MemberPersistencePort;
-import org.sopt.carena.member.application.port.out.RefreshTokenStore;
-import org.sopt.carena.member.application.service.util.JwtTokenGenerator;
 import org.sopt.carena.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,8 +25,6 @@ public class OAuth2LoginService implements OAuth2LoginUseCase {
 
     private final MemberPersistencePort memberPersistencePort;
     private final JoinTokenStore joinTokenStore;
-    private final RefreshTokenStore refreshTokenStore;
-    private final JwtTokenGenerator jwtTokenGenerator;
 
     @Override
     public OAuth2LoginResult processLogin(final OAuth2LoginCommand command) {
@@ -48,17 +44,18 @@ public class OAuth2LoginService implements OAuth2LoginUseCase {
     private LoginSuccessView handleExistingMember(final Member member) {
         log.info("기존 회원 로그인 - MemberId: {}", member.getId());
 
-        String accessToken = jwtTokenGenerator.createAccessToken(member.getId());
-        String refreshToken = jwtTokenGenerator.createRefreshToken(member.getId());
+        String oneTimeToken = UUID.randomUUID().toString();
+        String authInfo = String.join("|", member.getAuthType().name(), member.getAuthId());
 
-        // Refresh Token 저장
-        refreshTokenStore.save(
-                member.getId(),
-                refreshToken
+        //OTT 저장
+        joinTokenStore.save(
+                oneTimeToken,
+                authInfo,
+                Duration.ofMinutes(5)
         );
+
         return LoginSuccessView.of(
-                accessToken,
-                refreshToken,
+                oneTimeToken,
                 MemberView.from(member)
         );
     }

--- a/src/main/java/org/sopt/carena/member/application/service/RefreshTokenService.java
+++ b/src/main/java/org/sopt/carena/member/application/service/RefreshTokenService.java
@@ -2,7 +2,7 @@ package org.sopt.carena.member.application.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.carena.member.application.dto.view.TokenRefreshView;
+import org.sopt.carena.member.application.dto.view.TokenGeneratedView;
 import org.sopt.carena.member.application.service.util.JwtTokenGenerator;
 import org.sopt.carena.member.application.service.util.JwtTokenParser;
 import org.sopt.carena.member.application.service.util.JwtTokenValidator;
@@ -24,7 +24,7 @@ public class RefreshTokenService implements RefreshTokenUseCase {
     private final JwtTokenValidator jwtTokenValidator;
 
     @Override
-    public TokenRefreshView refreshAccessToken(final String refreshToken) {
+    public TokenGeneratedView refreshAccessToken(final String refreshToken) {
         log.info("Access Token 재발급 요청");
         jwtTokenValidator.validateToken(refreshToken);
 
@@ -41,6 +41,6 @@ public class RefreshTokenService implements RefreshTokenUseCase {
 
         refreshTokenStore.delete(memberId);
         refreshTokenStore.save(memberId, newRefreshToken);
-        return new TokenRefreshView(newAccessToken,newRefreshToken);
+        return new TokenGeneratedView(newAccessToken,newRefreshToken);
     }
 }

--- a/src/main/java/org/sopt/carena/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/org/sopt/carena/member/exception/code/MemberErrorCode.java
@@ -23,7 +23,9 @@ public enum MemberErrorCode implements ErrorResultCode {
     TOKEN_SIGNATURE_ERROR(HttpStatus.UNAUTHORIZED, "토큰 서명 검증에 실패했습니다."),
     EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 비어있습니다."),
     // OAuth
-    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth 제공자입니다.");
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth 제공자입니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"회원을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt/carena/member/exception/jwt/MemberNotFoundException.java
+++ b/src/main/java/org/sopt/carena/member/exception/jwt/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package org.sopt.carena.member.exception.jwt;
+
+import org.sopt.carena.global.exception.BaseException;
+import org.sopt.carena.member.exception.code.MemberErrorCode;
+
+public class MemberNotFoundException extends BaseException {
+    public MemberNotFoundException() {
+        super(MemberErrorCode.MEMBER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## **🚀 Related issue**

closes #17 

## **#️⃣ Summary**

- 로그인 성공시 oneTimeToken을 발급해주고 해당 토큰을 이용해 서비스에서 이용할 엑세스토큰 및 리프레시토큰을 발급하는 API를 호출하는 기능을 구현하였습니다.

## **🎯 Work Description**

- [x] 로그인 성공시 oneTimeToken을 쿠키에 담아 리다이렉트 처리
- [x] 토큰 발급 api요청시 저장된 oneTimeToken과 비교 후 엑세스토큰 및 리프레시 토큰 발급 처리
- [x] 엑세스토큰은 헤더에, 리프레시토큰은 쿠키에 담아 반환하도록 처리

## **👍 동작 확인**

- swagger나 postman 결과를 캡쳐하여 첨부
<img width="1002" height="569" alt="image" src="https://github.com/user-attachments/assets/4506167c-2e2e-4e5d-9a7f-e355889fbeca" />

## **💬 To Reviewers**

- 리뷰어나 같이 작업하는 사람들에게 남길 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 후 일회용 토큰 발급 흐름 도입 및 일회용 토큰으로 액세스/리프레시 토큰을 발급하는 신규 엔드포인트 추가
  * 로그인 응답이 일회용 토큰을 반환하도록 변경 및 토큰 발급 성공 메시지 추가
  * 토큰 발급을 담당하는 신규 서비스/인터페이스 도입

* **문서**
  * 일부 API 문서/시그니처 정리 및 신규 토큰 발급 API 설명 추가

* **버그 수정**
  * 회원 미조회 시 명확한 오류 코드/예외 추가 및 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->