### PR TITLE
feat: 건강검진 결과 저장시 날짜 검증 추가

### DIFF
--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
@@ -33,7 +33,7 @@ public class HealthReportPersistenceAdapter implements HealthReportPersistencePo
 	}
 
 	public boolean existsByMemberIdAndHealthCheckDate(long memberId, LocalDate healthCheckDate) {
-		return healthReportRepository.existsByMemberIdAndHealthCheckDate(memberId, healthCheckDate);
+		return healthReportRepository.existsByMemberEntityIdAndHealthCheckDate(memberId, healthCheckDate);
 	}
 
 	public Slice<HealthReport> findAllByMemberIdOrderByHealthCheckDateDesc(final long memberId, final int index) {

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package org.sopt.carena.healthreport.adapter.out.persistence;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,6 +30,10 @@ public class HealthReportPersistenceAdapter implements HealthReportPersistencePo
 		MemberEntity memberEntityProxy = memberJpaRepository.getReferenceById(healthReport.getMemberId());
 
 		return HealthReportMapper.toDomain(healthReportRepository.save(HealthReportMapper.toEntity(healthReport, memberEntityProxy)));
+	}
+
+	public boolean existsByMemberIdAndHealthCheckDate(long memberId, LocalDate healthCheckDate) {
+		return healthReportRepository.existsByMemberIdAndHealthCheckDate(memberId, healthCheckDate);
 	}
 
 	public Slice<HealthReport> findAllByMemberIdOrderByHealthCheckDateDesc(final long memberId, final int index) {

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/repository/HealthReportRepository.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/repository/HealthReportRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.carena.healthreport.adapter.out.persistence.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +12,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface HealthReportRepository extends JpaRepository<HealthReportEntity, Long> {
 
 	Optional<HealthReportEntity> findByMemberEntityIdAndId(long memberId, long healthReportId);
+
+	boolean existsByMemberIdAndHealthCheckDate(Long memberId, LocalDate healthCheckDate);
 
 	Slice<HealthReportEntity> findAllByMemberEntityIdOrderByHealthCheckDateDesc(long memberId, Pageable pageable);
 

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/repository/HealthReportRepository.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/repository/HealthReportRepository.java
@@ -13,7 +13,7 @@ public interface HealthReportRepository extends JpaRepository<HealthReportEntity
 
 	Optional<HealthReportEntity> findByMemberEntityIdAndId(long memberId, long healthReportId);
 
-	boolean existsByMemberIdAndHealthCheckDate(Long memberId, LocalDate healthCheckDate);
+	boolean existsByMemberEntityIdAndHealthCheckDate(Long memberId, LocalDate healthCheckDate);
 
 	Slice<HealthReportEntity> findAllByMemberEntityIdOrderByHealthCheckDateDesc(long memberId, Pageable pageable);
 

--- a/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
@@ -1,5 +1,6 @@
 package org.sopt.carena.healthreport.application.port.out;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -8,6 +9,8 @@ import org.springframework.data.domain.Slice;
 
 public interface HealthReportPersistencePort {
 	HealthReport saveHealthReport(HealthReport healthReport);
+
+	boolean existsByMemberIdAndHealthCheckDate(long memberId, LocalDate healthCheckDate);
 
 	Slice<HealthReport> findAllByMemberIdOrderByHealthCheckDateDesc(long memberId, int index);
 

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -12,6 +12,7 @@ import org.sopt.carena.healthreport.domain.HealthReport;
 import org.sopt.carena.healthreport.domain.HealthReportEmbedding;
 import org.sopt.carena.healthreport.domain.status.HealthStatusCarrier;
 import org.sopt.carena.healthreport.domain.status.RiskLevel;
+import org.sopt.carena.healthreport.exception.healthreport.HealthReportAlreadyExistsException;
 import org.sopt.carena.member.application.port.out.MemberPersistencePort;
 import org.sopt.carena.member.domain.Member;
 
@@ -32,6 +33,13 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 	public void createHealthReport(final CreateHealthReportCommand commend) {
 		Member member = memberPersistencePort.getMemberById(commend.memberId())
 				.orElseThrow(MemberNotFoundException::new);
+
+		if (healthReportPersistencePort.existsByMemberIdAndHealthCheckDate(
+				commend.memberId(),
+				commend.healthCheckDate()
+		)) {
+			throw new HealthReportAlreadyExistsException();
+		}
 
 		HealthReport healthReport = healthReportPersistencePort
 				.saveHealthReport(HealthReport.create(commend, member.getGender()));

--- a/src/main/java/org/sopt/carena/healthreport/exception/code/ErrorCode.java
+++ b/src/main/java/org/sopt/carena/healthreport/exception/code/ErrorCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode implements ErrorResultCode {
 	HEALTH_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "건강 검진 데이터가 존재하지 않습니다."),
 	MESSAGE_SERIALIZATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 요청메시지 생성에 실패했습니다."),
-	OCR_API_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "OCR API 호출에 실패했습니다.");
+	OCR_API_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "OCR API 호출에 실패했습니다."),
+	ALREADY_EXIST_REPORT(HttpStatus.CONFLICT,"해당 날짜에 이미 건강검진 리포트가 존재합니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/sopt/carena/healthreport/exception/healthreport/HealthReportAlreadyExistsException.java
+++ b/src/main/java/org/sopt/carena/healthreport/exception/healthreport/HealthReportAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package org.sopt.carena.healthreport.exception.healthreport;
+
+import org.sopt.carena.global.exception.BaseException;
+import org.sopt.carena.healthreport.exception.code.ErrorCode;
+
+public class HealthReportAlreadyExistsException extends BaseException {
+    public HealthReportAlreadyExistsException() {
+        super(ErrorCode.ALREADY_EXIST_REPORT);
+    }
+}


### PR DESCRIPTION
## **🚀 Related issue**

closes #29

## **#️⃣ Summary**

- 건강검진 추가시 해당 날짜에 이미 건강검진 결과가 존재하면 추가 못하도록 구현

## **🎯 Work Description**

- [x] 날짜 검증 추가
- [ ] 작업 내용

## **👍 동작 확인**

- swagger나 postman 결과를 캡쳐하여 첨부
<img width="980" height="751" alt="image" src="https://github.com/user-attachments/assets/db9b1342-bac1-4fd8-a6fd-7cf014f72335" />


## **💬 To Reviewers**

- 리뷰어나 같이 작업하는 사람들에게 남길 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동일한 날짜에 건강검진 리포트 중복 생성 방지 기능 추가. 같은 날짜에 이미 존재하는 리포트에 대해 재등록 시 오류 메시지를 통해 사용자에게 안내합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->