### PR TITLE
feat: 건강팁 추가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     implementation "org.hibernate.orm:hibernate-vector:6.6.40.Final"
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // auth
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/org/sopt/carena/global/config/QueryDslConfig.java
+++ b/src/main/java/org/sopt/carena/global/config/QueryDslConfig.java
@@ -1,0 +1,22 @@
+package org.sopt.carena.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+	@PersistenceContext
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(() -> entityManager);
+	}
+}

--- a/src/main/java/org/sopt/carena/healthtip/adapter/in/web/controller/HealthTipApiDocs.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/in/web/controller/HealthTipApiDocs.java
@@ -4,7 +4,9 @@ import org.sopt.carena.global.api.response.SuccessResponse;
 import org.sopt.carena.healthtip.adapter.in.request.CreateHealthTipRequest;
 import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipDetailView;
 import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipListView;
+import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipTickerView;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,7 +16,10 @@ import jakarta.validation.constraints.Min;
 @Tag(name = "건강팁 큐레이션", description = "건강팁 큐레이션 관련 API")
 public interface HealthTipApiDocs {
 	@Operation(summary = "건강팁 목록 조회", description = "건강팁의 목록을 조회합니다.")
-	ResponseEntity<SuccessResponse<ReadHealthTipListView>> readHealthTipList(@Min(1) int page);
+	ResponseEntity<SuccessResponse<ReadHealthTipListView>> readHealthTipList(@Min(1) int page, String hashtagName);
+
+	@Operation(summary = "Ticker에서의 건강팁 목록 조회",description = "Ticker에 표시할 건강팁의 목록을 조회합니다.")
+	ResponseEntity<SuccessResponse<ReadHealthTipTickerView>> readHealthTipTicker(long memberId);
 
 	@Operation(summary = "건강팁 상세 조회", description = "특정 ID에 해당하는 건강팁의 세부 내용을 조회합니다.")
 	ResponseEntity<SuccessResponse<ReadHealthTipDetailView>> readHealthTipDetail(long healthTipId);

--- a/src/main/java/org/sopt/carena/healthtip/adapter/in/web/controller/HealthTipController.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/in/web/controller/HealthTipController.java
@@ -7,11 +7,14 @@ import org.sopt.carena.healthtip.adapter.in.web.code.SuccessCode;
 import org.sopt.carena.healthtip.application.dto.command.CreateHealthTipCommand;
 import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipDetailView;
 import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipListView;
+import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipTickerView;
 import org.sopt.carena.healthtip.application.port.in.CreateHealthTipUseCase;
 import org.sopt.carena.healthtip.application.port.in.DeleteHealthTipUseCase;
 import org.sopt.carena.healthtip.application.port.in.ReadHealthTipDetailUseCase;
 import org.sopt.carena.healthtip.application.port.in.ReadHealthTipListUseCase;
+import org.sopt.carena.healthtip.application.port.in.ReadHealthTipTickerUseCase;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,16 +34,27 @@ import lombok.RequiredArgsConstructor;
 public class HealthTipController implements HealthTipApiDocs {
 	private final CreateHealthTipUseCase createHealthTipUseCase;
 	private final ReadHealthTipListUseCase readHealthTipListUseCase;
+	private final ReadHealthTipTickerUseCase readHealthTipTickerUseCase;
 	private final ReadHealthTipDetailUseCase readHealthTipDetailUseCase;
 	private final DeleteHealthTipUseCase deleteHealthTipUseCase;
 
 	@GetMapping
 	public ResponseEntity<SuccessResponse<ReadHealthTipListView>> readHealthTipList(
-			@RequestParam(name = "page", defaultValue = "1") @Min(1) final int page
+			@RequestParam(name = "page", defaultValue = "1") @Min(1) final int page,
+			@RequestParam(name = "hashtagName", required = false) final String hashtagName
 	) {
 		return ResponseEntity.status(SuccessCode.HEALTH_TIP_FOUND.getStatus())
 				.body(ApiResponse.success(SuccessCode.HEALTH_TIP_FOUND,
-						readHealthTipListUseCase.readHealthTipList(page)));
+						readHealthTipListUseCase.readHealthTipList(hashtagName, page)));
+	}
+
+	@GetMapping(path = "/ticker")
+	public ResponseEntity<SuccessResponse<ReadHealthTipTickerView>> readHealthTipTicker(
+			@AuthenticationPrincipal final long memberId
+	){
+		return ResponseEntity.status(SuccessCode.HEALTH_TIP_FOUND.getStatus())
+				.body(ApiResponse.success(SuccessCode.HEALTH_TIP_FOUND,
+						readHealthTipTickerUseCase.readHealthTipTicker(memberId)));
 	}
 
 	@GetMapping(path = "/{healthTipId}")

--- a/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/HealthTipPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/HealthTipPersistenceAdapter.java
@@ -29,10 +29,17 @@ public class HealthTipPersistenceAdapter implements HealthTipPersistencePort {
 	private final HashtagEntityRepository hashtagEntityRepository;
 	private final HealthTipHashtagEntityRepository healthTipHashtagEntityRepository;
 
-	public Slice<HealthTip> getHealthTipList(final int page) {
+	public Slice<HealthTip> getHealthTipList(final String hashtagName, final int page) {
 		Pageable pageable = PageRequest.of(page - 1, 10);
-		return healthTipEntityRepository.findAllByOrderByIdDesc(pageable)
+
+		return healthTipEntityRepository.findHealthTipListWithHashTags(hashtagName, pageable)
 				.map(HealthTipMapper::toDomainWithoutHashtags);
+	}
+
+	public List<HealthTip> getHealthTipTicker(final String hashtagName) {
+		return healthTipEntityRepository.findRandomHealthTipsWithHashtags(hashtagName,3).stream()
+				.map(HealthTipMapper::toDomain)
+				.toList();
 	}
 
 	public Optional<HealthTip> getHealthTipDetail(final long id) {

--- a/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/entity/HealthTipEntity.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/entity/HealthTipEntity.java
@@ -36,6 +36,9 @@ public class HealthTipEntity {
 	@Column(name = "reference", nullable = false)
 	private String reference;
 
+	@OneToMany(mappedBy = "healthTip", fetch = FetchType.LAZY)
+	List<HealthTipHashtagEntity> hashtags = new ArrayList<>();
+
 	@Builder
 	public HealthTipEntity(String title, String subTitle, String content, String reference) {
 		this.title = title;
@@ -43,7 +46,4 @@ public class HealthTipEntity {
 		this.content = content;
 		this.reference = reference;
 	}
-
-	@OneToMany(mappedBy = "healthTip", fetch = FetchType.LAZY)
-	List<HealthTipHashtagEntity> hashtags = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipEntityRepository.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipEntityRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.carena.healthtip.adapter.out.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.sopt.carena.healthtip.adapter.out.persistence.entity.HealthTipEntity;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface HealthTipEntityRepository extends JpaRepository<HealthTipEntity, Long> {
+public interface HealthTipEntityRepository extends JpaRepository<HealthTipEntity, Long>, HealthTipSearchRepository{
 	Slice<HealthTipEntity> findAllByOrderByIdDesc(Pageable pageable);
 
 	@Query("""
@@ -19,5 +20,8 @@ public interface HealthTipEntityRepository extends JpaRepository<HealthTipEntity
 				left join fetch hth.hashtag
 				where ht.id = :id
 			""")
-	Optional<HealthTipEntity> findByIdWithHashtags(@Param("id") long id);
+	Optional<HealthTipEntity> findByIdWithHashtags(@Param(value = "id") long id);
+
+	@Query(nativeQuery = true, value = "select * from health_tip order by random() limit :limit")
+	List<HealthTipEntity> findRandomHealthTipEntities(@Param(value = "limit") int limit);
 }

--- a/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipSearchRepository.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipSearchRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.carena.healthtip.adapter.out.persistence.repository;
+
+import java.util.List;
+
+import org.sopt.carena.healthtip.adapter.out.persistence.entity.HealthTipEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface HealthTipSearchRepository {
+	Slice<HealthTipEntity> findHealthTipListWithHashTags(String hashtagName,Pageable pageable);
+
+	List<HealthTipEntity> findRandomHealthTipsWithHashtags(String hashtagName, int limit);
+}

--- a/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipSearchRepositoryImpl.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipSearchRepositoryImpl.java
@@ -79,7 +79,6 @@ public class HealthTipSearchRepositoryImpl implements HealthTipSearchRepository 
 		// 해시태그 조건을 만족하는 ID 중 랜덤 N개
 		List<Long> ids = queryFactory
 				.select(ht.id)
-				.distinct()
 				.from(ht)
 				.join(ht.hashtags, hth)
 				.join(hth.hashtag, h)

--- a/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipSearchRepositoryImpl.java
+++ b/src/main/java/org/sopt/carena/healthtip/adapter/out/persistence/repository/HealthTipSearchRepositoryImpl.java
@@ -1,0 +1,104 @@
+package org.sopt.carena.healthtip.adapter.out.persistence.repository;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.sopt.carena.healthtip.adapter.out.persistence.entity.HealthTipEntity;
+import org.sopt.carena.healthtip.adapter.out.persistence.entity.QHashtagEntity;
+import org.sopt.carena.healthtip.adapter.out.persistence.entity.QHealthTipEntity;
+import org.sopt.carena.healthtip.adapter.out.persistence.entity.QHealthTipHashtagEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class HealthTipSearchRepositoryImpl implements HealthTipSearchRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public Slice<HealthTipEntity> findHealthTipListWithHashTags(
+			String hashtagName, Pageable pageable) {
+
+		QHealthTipEntity ht = QHealthTipEntity.healthTipEntity;
+		QHealthTipHashtagEntity hth = QHealthTipHashtagEntity.healthTipHashtagEntity;
+		QHashtagEntity h = QHashtagEntity.hashtagEntity;
+
+		List<Long> ids = queryFactory
+				.select(ht.id)
+				.distinct()
+				.from(ht)
+				.join(ht.hashtags, hth)
+				.join(hth.hashtag, h)
+				.where(hashtagNameEq(hashtagName))
+				.orderBy(ht.id.desc())
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize() + 1)
+				.fetch();
+
+		if (ids.isEmpty()) {
+			return new SliceImpl<>(Collections.emptyList(), pageable, false);
+		}
+
+		List<HealthTipEntity> healthTips = queryFactory
+				.selectFrom(ht)
+				.leftJoin(ht.hashtags, hth).fetchJoin()
+				.leftJoin(hth.hashtag, h).fetchJoin()
+				.where(
+						ht.id.in(ids)
+				)
+				.orderBy(ht.id.desc())
+				.fetch();
+
+		boolean hasNext = ids.size() > pageable.getPageSize();
+		if (hasNext) {
+			healthTips.removeLast();
+		}
+
+		return new SliceImpl<>(healthTips, pageable, hasNext);
+	}
+
+	private BooleanExpression hashtagNameEq(String hashtagName) {
+		if (hashtagName == null || hashtagName.isBlank()) {
+			return null;
+		}
+		return QHashtagEntity.hashtagEntity.name.eq(hashtagName);
+	}
+
+	public List<HealthTipEntity> findRandomHealthTipsWithHashtags(final String hashtagName, final int limit) {
+		QHealthTipEntity ht = QHealthTipEntity.healthTipEntity;
+		QHealthTipHashtagEntity hth = QHealthTipHashtagEntity.healthTipHashtagEntity;
+		QHashtagEntity h = QHashtagEntity.hashtagEntity;
+
+		// 해시태그 조건을 만족하는 ID 중 랜덤 N개
+		List<Long> ids = queryFactory
+				.select(ht.id)
+				.distinct()
+				.from(ht)
+				.join(ht.hashtags, hth)
+				.join(hth.hashtag, h)
+				.where(h.name.eq(hashtagName))
+				.orderBy(Expressions.numberTemplate(
+						Double.class, "random()").asc())
+				.limit(limit)
+				.fetch();
+
+		if (ids.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		// fetch join으로 연관 엔티티 한방에 로딩
+		return queryFactory
+				.selectFrom(ht)
+				.leftJoin(ht.hashtags, hth).fetchJoin()
+				.leftJoin(hth.hashtag, h).fetchJoin()
+				.where(ht.id.in(ids))
+				.fetch();
+	}
+}

--- a/src/main/java/org/sopt/carena/healthtip/application/dto/view/HealthTipListElement.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/dto/view/HealthTipListElement.java
@@ -1,0 +1,12 @@
+package org.sopt.carena.healthtip.application.dto.view;
+
+import org.sopt.carena.healthtip.domain.HealthTip;
+
+public record HealthTipListElement(
+		Long id,
+		String title
+) {
+	public static HealthTipListElement from(final HealthTip healthTip) {
+		return new HealthTipListElement(healthTip.getId(), healthTip.getTitle());
+	}
+}

--- a/src/main/java/org/sopt/carena/healthtip/application/dto/view/ReadHealthTipListView.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/dto/view/ReadHealthTipListView.java
@@ -16,13 +16,4 @@ public record ReadHealthTipListView(
 
 		return new ReadHealthTipListView(elements, healthTipList.hasNext());
 	}
-
-	private record HealthTipListElement(
-			Long id,
-			String title
-	) {
-		private static HealthTipListElement from(final HealthTip healthTip) {
-			return new HealthTipListElement(healthTip.getId(), healthTip.getTitle());
-		}
-	}
 }

--- a/src/main/java/org/sopt/carena/healthtip/application/dto/view/ReadHealthTipTickerView.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/dto/view/ReadHealthTipTickerView.java
@@ -1,0 +1,13 @@
+package org.sopt.carena.healthtip.application.dto.view;
+
+import java.util.List;
+
+import org.sopt.carena.healthtip.domain.HealthTip;
+
+public record ReadHealthTipTickerView(
+		List<HealthTipListElement> result
+) {
+	public static ReadHealthTipTickerView from(List<HealthTip> healthTips) {
+		return new ReadHealthTipTickerView(healthTips.stream().map(HealthTipListElement::from).toList());
+	}
+}

--- a/src/main/java/org/sopt/carena/healthtip/application/port/in/ReadHealthTipListUseCase.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/port/in/ReadHealthTipListUseCase.java
@@ -3,5 +3,5 @@ package org.sopt.carena.healthtip.application.port.in;
 import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipListView;
 
 public interface ReadHealthTipListUseCase {
-	ReadHealthTipListView readHealthTipList(int page);
+	ReadHealthTipListView readHealthTipList(String hashtagName, int page);
 }

--- a/src/main/java/org/sopt/carena/healthtip/application/port/in/ReadHealthTipTickerUseCase.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/port/in/ReadHealthTipTickerUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.healthtip.application.port.in;
+
+import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipTickerView;
+
+public interface ReadHealthTipTickerUseCase {
+	ReadHealthTipTickerView readHealthTipTicker(long memberId);
+}

--- a/src/main/java/org/sopt/carena/healthtip/application/port/out/HealthTipPersistencePort.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/port/out/HealthTipPersistencePort.java
@@ -8,7 +8,9 @@ import org.sopt.carena.healthtip.domain.value.Hashtag;
 import org.springframework.data.domain.Slice;
 
 public interface HealthTipPersistencePort {
-	Slice<HealthTip> getHealthTipList(int page);
+	Slice<HealthTip> getHealthTipList(String hashtagName, int page);
+
+	List<HealthTip> getHealthTipTicker(String hashtagName);
 
 	Optional<HealthTip> getHealthTipDetail(long id);
 

--- a/src/main/java/org/sopt/carena/healthtip/application/service/ReadHealthTipListService.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/service/ReadHealthTipListService.java
@@ -3,6 +3,9 @@ package org.sopt.carena.healthtip.application.service;
 import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipListView;
 import org.sopt.carena.healthtip.application.port.in.ReadHealthTipListUseCase;
 import org.sopt.carena.healthtip.application.port.out.HealthTipPersistencePort;
+import org.sopt.carena.member.application.port.out.MemberPersistencePort;
+import org.sopt.carena.member.domain.Member;
+import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -11,8 +14,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReadHealthTipListService implements ReadHealthTipListUseCase {
 	private final HealthTipPersistencePort healthTipPersistencePort;
+	private final MemberPersistencePort memberPersistencePort;
 
-	public ReadHealthTipListView readHealthTipList(final int page){
-		return ReadHealthTipListView.from(healthTipPersistencePort.getHealthTipList(page));
+	public ReadHealthTipListView readHealthTipList(final String hashtagName, final int page){
+		// Member member = memberPersistencePort.getMemberById(memberId).orElseThrow(MemberNotFoundException::new);
+
+		// 20, 30, 40, 50, 60
+		// member.getAge()
+
+		return ReadHealthTipListView.from(healthTipPersistencePort.getHealthTipList(hashtagName, page));
 	}
 }

--- a/src/main/java/org/sopt/carena/healthtip/application/service/ReadHealthTipTickerService.java
+++ b/src/main/java/org/sopt/carena/healthtip/application/service/ReadHealthTipTickerService.java
@@ -1,0 +1,30 @@
+package org.sopt.carena.healthtip.application.service;
+
+import org.sopt.carena.healthtip.application.dto.view.ReadHealthTipTickerView;
+import org.sopt.carena.healthtip.application.port.in.ReadHealthTipTickerUseCase;
+import org.sopt.carena.healthtip.application.port.out.HealthTipPersistencePort;
+import org.sopt.carena.member.application.port.out.MemberPersistencePort;
+import org.sopt.carena.member.domain.Member;
+import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReadHealthTipTickerService implements ReadHealthTipTickerUseCase {
+	private final HealthTipPersistencePort healthTipPersistencePort;
+	private final MemberPersistencePort memberPersistencePort;
+
+	public ReadHealthTipTickerView readHealthTipTicker(final long memberId) {
+		Member member = memberPersistencePort.getMemberById(memberId).orElseThrow(MemberNotFoundException::new);
+
+		return ReadHealthTipTickerView.from(healthTipPersistencePort.getHealthTipTicker(getAgeGroup(member.getAge())));
+	}
+
+	private String getAgeGroup(final int age){
+		int normalizedAge = Math.min(Math.max(age, 20), 60);
+		int ageGroup = (normalizedAge / 10) * 10;
+		return ageGroup + "대";
+	}
+}


### PR DESCRIPTION
## **🚀 Related issue**

closes #28 

## **#️⃣ Summary**

- 건강팁 도메인에서 ticker를 위한 랜덤 조회 기능을 추가로 구현합니다.
- 조회를 요청한 사용자의 나이에 맞는 태그의 필터링을 구현합니다.

## **🎯 Work Description**

- [x] 건강팁 아티클 랜덤 조회 기능 구현
- [x] 건강팁 태그 필터링 기능 구현

## **👍 동작 확인**

- ticker에서 조회
  <img width="760" height="668" alt="스크린샷 2026-01-19 오전 12 09 08" src="https://github.com/user-attachments/assets/bc6e0d3f-f7a1-466a-9c1a-112ad0b2105e" />

- 조회 페이지에서 태그 필터링 적용
  <img width="757" height="659" alt="스크린샷 2026-01-19 오전 12 07 14" src="https://github.com/user-attachments/assets/7c66009a-62d9-4b36-a39a-6303bd460389" />


## **💬 To Reviewers**

- 두 기능 모두 쿼리 dsl로 동적 쿼리 및 조인+페이지네이션을 적용하였습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 건강 팁에 해시태그 필터링 기능 추가
  * 사용자의 나이대에 맞는 건강 팁을 무작위로 추천하는 티커 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->