### PR TITLE
fix: diet chunks엔티티에 metadata추가

### DIFF
--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/DietJpaPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/DietJpaPersistenceAdapter.java
@@ -1,6 +1,5 @@
 package org.sopt.carena.diet.adapter.out.persistence;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.carena.diet.adapter.out.persistence.entity.CautionCategoryEntity;
@@ -8,10 +7,8 @@ import org.sopt.carena.diet.adapter.out.persistence.entity.DietChunkEntity;
 import org.sopt.carena.diet.adapter.out.persistence.entity.DietInformationEntity;
 import org.sopt.carena.diet.adapter.out.persistence.entity.RecommendedCategoryEntity;
 import org.sopt.carena.diet.adapter.out.persistence.mapper.DietPersistenceMapper;
-import org.sopt.carena.diet.adapter.out.persistence.repository.CautionCategoryRepository;
+import org.sopt.carena.diet.adapter.out.persistence.repository.DietChunkJpaRepository;
 import org.sopt.carena.diet.adapter.out.persistence.repository.DietInformationJpaRepository;
-import org.sopt.carena.diet.adapter.out.persistence.repository.RecommendedCategoryRepository;
-import org.sopt.carena.diet.application.dto.view.DietDetailResultView;
 import org.sopt.carena.diet.application.port.out.DietPersistencePort;
 import org.sopt.carena.diet.domain.value.DietChunk;
 import org.sopt.carena.diet.domain.DietInformation;
@@ -31,21 +28,38 @@ public class DietJpaPersistenceAdapter implements DietPersistencePort {
 
     private final DietInformationJpaRepository infoRepository;
     private final DietPersistenceMapper mapper;
+    private final DietChunkJpaRepository dietChunkRepository;
 
     @Override
-    public void save(final DietInformation info, final List<DietChunk> chunks,
-                     final String content,
-                     final Map<String, List<String>> recommends,
-                     final List<String> cautionary) {
-
+    @Transactional
+    public Long saveInformation(final DietInformation info) {
+        // DietInformation만 저장 (청크 제외)
         DietInformationEntity infoEntity = new DietInformationEntity(
                 info.getTitle(),
-                content,
+                info.getContent(),
                 info.getReference(),
                 info.getReferenceUrl()
         );
 
-        // DietChunk
+        infoEntity = infoRepository.save(infoEntity);
+
+        log.debug("DietInformation 저장 완료 - ID: {}", infoEntity.getId());
+        return infoEntity.getId();
+    }
+
+    @Override
+    @Transactional
+    public void saveChunksAndCategories(
+            final Long documentId,
+            final List<DietChunk> chunks,
+            final Map<String, List<String>> recommends,
+            final List<String> cautionary) {
+
+        // DietInformation 조회
+        DietInformationEntity infoEntity = infoRepository.findById(documentId)
+                .orElseThrow(() -> new IllegalArgumentException("Document not found: " + documentId));
+
+        //  청크 엔티티 생성
         List<DietChunkEntity> chunkEntities = chunks.stream()
                 .map(chunk -> new DietChunkEntity(
                         infoEntity,
@@ -53,32 +67,28 @@ public class DietJpaPersistenceAdapter implements DietPersistencePort {
                         chunk.getContent(),
                         chunk.getEmbeddingText(),
                         chunk.getEmbedding(),
-                        chunk.getChunkOrder()
+                        chunk.getChunkOrder(),
+                        chunk.getMetadata()
                 ))
                 .toList();
-        // 양방향 관계 설정
-        infoEntity.addAllChunks(chunkEntities);
 
         // RecommendedCategory
         if (recommends != null && !recommends.isEmpty()) {
-            RecommendedCategoryEntity recommendedEntity = new RecommendedCategoryEntity(
-                    infoEntity,
-                    recommends
-            );
+            RecommendedCategoryEntity recommendedEntity =
+                    new RecommendedCategoryEntity(infoEntity, recommends);
             infoEntity.setRecommendedFood(recommendedEntity);
         }
 
+        // CautionaryFoods
         if (cautionary != null && !cautionary.isEmpty()) {
-            CautionCategoryEntity cautionaryEntity = new CautionCategoryEntity(
-                    infoEntity,
-                    cautionary
-            );
+            CautionCategoryEntity cautionaryEntity =
+                    new CautionCategoryEntity(infoEntity, cautionary);
             infoEntity.setCautionaryFood(cautionaryEntity);
         }
+        dietChunkRepository.saveAll(chunkEntities);
 
-        infoRepository.save(infoEntity);
+        log.debug("청크 및 카테고리 저장 완료 - 청크 개수: {}", chunkEntities.size());
     }
-
     @Override
     @Transactional(readOnly = true)
     public Optional<DietInformation> loadById(Long dietId) {

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/CautionCategoryEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/CautionCategoryEntity.java
@@ -21,7 +21,7 @@ public class CautionCategoryEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diet_information_id", nullable = false)
+    @JoinColumn(name = "diet_information_id", nullable = false,foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private DietInformationEntity dietInformation;
 
     @Type(JsonType.class)

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietChunkEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietChunkEntity.java
@@ -11,6 +11,7 @@ import org.sopt.carena.diet.domain.value.DietSection;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Table(name = "diet_chunk")
@@ -41,6 +42,9 @@ public class DietChunkEntity {
     @Basic(fetch = FetchType.LAZY)
     private float[] embedding;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> metadata;
+
     @Column(nullable = false)
     private int chunkOrder;
 
@@ -53,7 +57,8 @@ public class DietChunkEntity {
             String content,
             String embeddingText,
             float[] embedding,
-            int chunkOrder
+            int chunkOrder,
+            Map<String, Object> metadata
     ) {
         this.document = document;
         this.section = section;
@@ -61,5 +66,6 @@ public class DietChunkEntity {
         this.embeddingText = embeddingText;
         this.embedding = embedding;
         this.chunkOrder = chunkOrder;
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietChunkEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietChunkEntity.java
@@ -24,7 +24,7 @@ public class DietChunkEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diet_information_id", nullable = false)
+    @JoinColumn(name = "diet_information_id", nullable = false,foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private DietInformationEntity document;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
@@ -37,7 +37,6 @@ public class DietInformationEntity {
     @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL)
     private RecommendedCategoryEntity recommendedFood;
 
-    //@OneToOne(mappedBy = "dietInformation", cascade = CascadeType.ALL, orphanRemoval = true)
     @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL)
     private CautionCategoryEntity cautionaryFood;
 
@@ -53,15 +52,11 @@ public class DietInformationEntity {
     public DietInformationEntity(
             String title,
             String content,
-            //List<String> recommends,
-            //List<String> cautionary,
             String reference,
             String referenceUrl
     ) {
         this.title = title;
         this.content = content;
-        //this.recommends = recommends;
-        //this.cautionary = cautionary;
         this.reference = reference;
         this.referenceUrl = referenceUrl;
     }

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
@@ -30,27 +30,16 @@ public class DietInformationEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "document")
     private List<DietChunkEntity> chunks = new ArrayList<>();
 
-    @OneToOne(mappedBy = "dietInformation", cascade = CascadeType.ALL, orphanRemoval = true)
+
+    @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL)
     private RecommendedCategoryEntity recommendedFood;
 
-    @OneToOne(mappedBy = "dietInformation", cascade = CascadeType.ALL, orphanRemoval = true)
+    //@OneToOne(mappedBy = "dietInformation", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL)
     private CautionCategoryEntity cautionaryFood;
-
-
-/*
-    @Type(JsonType.class)
-    @Column(columnDefinition = "jsonb")
-    private List<String> recommends;
-
-    @Type(JsonType.class)
-    @Column(columnDefinition = "jsonb")
-    private List<String> cautionary;
-
- */
-
 
     private String reference;
     private String referenceUrl;

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
@@ -30,14 +30,14 @@ public class DietInformationEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @OneToMany(mappedBy = "document")
+    @OneToMany(mappedBy = "document",cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<DietChunkEntity> chunks = new ArrayList<>();
 
 
-    @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL, orphanRemoval = true)
     private RecommendedCategoryEntity recommendedFood;
 
-    @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL, orphanRemoval = true)
     private CautionCategoryEntity cautionaryFood;
 
     private String reference;

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/RecommendedCategoryEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/RecommendedCategoryEntity.java
@@ -23,7 +23,7 @@ public class RecommendedCategoryEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diet_information_id", nullable = false)
+    @JoinColumn(name = "diet_information_id", nullable = false,foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private DietInformationEntity dietInformation;
 
     @Type(JsonType.class)

--- a/src/main/java/org/sopt/carena/diet/application/port/out/DietPersistencePort.java
+++ b/src/main/java/org/sopt/carena/diet/application/port/out/DietPersistencePort.java
@@ -10,11 +10,15 @@ import java.util.Map;
 import java.util.Optional;
 
 public interface DietPersistencePort {
-    void save(DietInformation info,
-              List<DietChunk> chunks,
-              String content,
-              Map<String, List<String>> recommends,
-              List<String> cautionary
+    //Information만 저장하고 ID 반환
+    Long saveInformation(DietInformation info);
+
+    // 청크 + 카테고리 한 번에 저장
+    void saveChunksAndCategories(
+            Long documentId,
+            List<DietChunk> chunks,
+            Map<String, List<String>> recommends,
+            List<String> cautionary
     );
     Optional<DietInformation> loadById(Long dietId);
     Slice<DietInformation> loadDietList(Pageable pageable);

--- a/src/main/java/org/sopt/carena/diet/application/service/RegisterDietDocumentService.java
+++ b/src/main/java/org/sopt/carena/diet/application/service/RegisterDietDocumentService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -22,55 +23,75 @@ public class RegisterDietDocumentService
 
     private final DietEmbeddingTextService dietEmbeddingTextService;
     private final DietPersistencePort dietPersistencePort;
-    private final DietContentExtractor contentExtractor;
     private final EmbeddingPort embeddingPort;
 
     @Override
     @Transactional
     public void register(final CreateDietCommand command) {
+        try {
+            // 1. 도메인 생성
+            DietInformation document = toDomain(command);
+            List<DietChunk> chunks = document.getChunks();
+            String documentTitle = document.getTitle();
 
-       try {
-           DietInformation document = toDomain(command);
-           String content = document.getContent();
-           List<DietChunk> chunks = document.getChunks();
+            log.info("식단 정보를 등록합니다: {}", documentTitle);
 
-           String documentTitle = command.title();
+            // 2. 임베딩 텍스트 생성
+            List<String> embeddingTexts = chunks.stream()
+                    .map(chunk -> dietEmbeddingTextService.generate(chunk, documentTitle))
+                    .toList();
 
-           log.info("식단 정보를 등록합니다. " + documentTitle);
+            log.debug("생성된 임베딩 텍스트 개수: {}", embeddingTexts.size());
 
-           // 모든 chunk의 임베딩 텍스트 생성
-           List<String> embeddingTexts = chunks.stream()
-                   .map(chunk -> dietEmbeddingTextService.generate(chunk, documentTitle))
-                   .toList();
+            // 3. 임베딩 벡터 생성
+            log.info("임베딩 생성 중 (Texts: {}개)", embeddingTexts.size());
+            List<EmbeddingVector> embeddings = embeddingPort.embedBatch(embeddingTexts);
+            log.info("생성된 임베딩 정보:");
+            log.info("  - 개수: {}", embeddings.size());
+            log.info("  - 차원: {}", embeddings.isEmpty() ? 0 : embeddings.get(0).vector().length);
 
-           log.debug("생성된 임베딩 텍스트:");
-           embeddingTexts.forEach(text ->
-                   log.debug("  - {}", text.substring(0, Math.min(100, text.length())) + "...")
-           );
+            // 4. 임베딩 할당
+            for (int i = 0; i < chunks.size(); i++) {
+                chunks.get(i).assignEmbedding(
+                        embeddingTexts.get(i),
+                        embeddings.get(i).vector()
+                );
+                log.debug("Chunk {} 임베딩 할당 완료 (섹션: {})",
+                        i + 1, chunks.get(i).getSection());
+            }
 
+            // 5. Information 먼저 저장 후 ID 획득
+            Long documentId = dietPersistencePort.saveInformation(document);
+            log.info("DietInformation 저장 완료 - ID: {}", documentId);
 
-           log.info("Step 2: 임베딩 생성 중 (Texts: {}개)", embeddingTexts.size());
-           // 배치로 임베딩
-           List<EmbeddingVector> embeddings = embeddingPort.embedBatch(embeddingTexts);
-           log.info("생성된 임베딩 정보:");
-           log.info("  - 개수: {}", embeddings.size());
-           log.info("  - 차원: {}", embeddings.isEmpty() ? 0 : embeddings.get(0).vector().length);
+            // 6. Application에서 메타데이터 생성 및 할당
+            Map<String, Object> metadata = createChunkMetadata(documentId, documentTitle);
+            chunks.forEach(chunk -> chunk.assignMetadata(metadata));
+            log.debug("청크 메타데이터 생성 완료");
 
-           // 임베딩 할당
-           for (int i = 0; i < chunks.size(); i++) {
-               chunks.get(i).assignEmbedding(embeddingTexts.get(i), embeddings.get(i).vector());
-               log.debug("Chunk {} 임베딩 할당 완료 (섹션: {})",
-                       i + 1, chunks.get(i).getSection());
-           }
+            // 7. 청크 + 카테고리 한 번에 저장
+            dietPersistencePort.saveChunksAndCategories(
+                    documentId,
+                    chunks,
+                    command.recommendedCategories(),
+                    command.cautionaryFoods()
+            );
 
-           log.info("Embedding 생성: " + embeddings);
-           //String content = contentExtractor.extractContent(chunks);
-           dietPersistencePort.save(document, chunks, content, command.recommendedCategories(), command.cautionaryFoods());
+            log.info("식단 정보 등록 성공: {}", documentTitle);
+        } catch (Exception e) {
+            log.error("식단 정보 등록 실패", e);
+            throw new EmbeddingFailedException();
+        }
+    }
 
-           log.info("식단 정보 등록 성공: {} with ", documentTitle);
-       } catch (Exception e) {
-           throw new EmbeddingFailedException();
-       }
+    /**
+     * 청크 메타데이터 생성
+     */
+    private Map<String, Object> createChunkMetadata(Long documentId, String title) {
+        return Map.of(
+                "document_id", documentId,
+                "title", title
+        );
     }
 
     private DietInformation toDomain(final CreateDietCommand command) {

--- a/src/main/java/org/sopt/carena/diet/domain/DietInformation.java
+++ b/src/main/java/org/sopt/carena/diet/domain/DietInformation.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @Getter
 public class DietInformation {
 
-    private final Long id;
+    private Long id;
     private final String title;
     private final String content;
     private final String reference;

--- a/src/main/java/org/sopt/carena/diet/domain/value/DietChunk.java
+++ b/src/main/java/org/sopt/carena/diet/domain/value/DietChunk.java
@@ -3,6 +3,8 @@ package org.sopt.carena.diet.domain.value;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 @Getter
 public class DietChunk {
 
@@ -13,6 +15,7 @@ public class DietChunk {
     // 임베딩 관련
     private String embeddingText;
     private float[] embedding;
+    private Map<String, Object> metadata;
 
     @Builder
     private DietChunk(
@@ -21,7 +24,8 @@ public class DietChunk {
             String content,
             int chunkOrder,
             String embeddingText,
-            float[] embedding
+            float[] embedding,
+            Map<String, Object> metadata
     ) {
         this.id = id;
         this.section = section;
@@ -29,10 +33,14 @@ public class DietChunk {
         this.chunkOrder = chunkOrder;
         this.embeddingText = embeddingText;
         this.embedding = embedding;
+        this.metadata = metadata;
     }
 
     public void assignEmbedding(String embeddingText, float[] embedding) {
         this.embeddingText = embeddingText;
         this.embedding = embedding;
+    }
+    public void assignMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/org/sopt/carena/diet/domain/value/RecommendedFoods.java
+++ b/src/main/java/org/sopt/carena/diet/domain/value/RecommendedFoods.java
@@ -15,4 +15,3 @@ public record RecommendedFoods(Map<String, List<String>> categories) {
         return categories.isEmpty();
     }
 }
-


### PR DESCRIPTION
## **🚀 Related issue**

closes #33 

## **#️⃣ Summary**

- 식단 청크 생성시 메타데이터도 함께 저장되도록 구현

## **🎯 Work Description**

- [ ] 식단 청크 생성시 메타데이터도 함께 저장
- [ ] 작업 내용

## **👍 동작 확인**

- swagger나 postman 결과를 캡쳐하여 첨부

<img width="884" height="226" alt="image" src="https://github.com/user-attachments/assets/199670f4-7389-4c4a-a0b3-477d90c1c87a" />


## **💬 To Reviewers**

- 리뷰어나 같이 작업하는 사람들에게 남길 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 식단 저장 흐름을 정보 저장과 청크/카테고리 저장의 두 단계로 분리
  * 데이터 모델과 DB 매핑을 정리해 관계 매핑 및 제약 최적화
  * 청크 메타데이터 구조 및 배치 임베딩 처리를 도입해 등록 흐름 단순화

* **New Features**
  * 청크별 메타데이터 저장 및 일괄 저장 지원

* **Bug Fixes**
  * 임베딩/저장 실패 시 예외 처리 및 로깅 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->