### PR TITLE
fix: 로그아웃, 로그인, 회원가입시 사용한 토큰 삭제처리 추가

### DIFF
--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
@@ -39,7 +39,6 @@ public class MemberController implements MemberApiDocs{
     private final GetMemberInfoUseCase getMemberInfoUseCase;
     private final GenerateTokenUseCase generateTokenUseCase;
     private final LogoutUseCase logoutUseCase;
-    //private final AccessTokenResolver accessTokenResolver;
 
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<Void>> signup(
@@ -48,7 +47,7 @@ public class MemberController implements MemberApiDocs{
             HttpServletResponse response
     ) {
         signupUseCase.signup(SignUpCommand.of(tempToken, request));
-        CookieUtil.deleteTempTokenCookie(response);
+        CookieUtil.deleteCookie(response,"tempToken");
         return ResponseEntity.status(MemberSuccessCode.SIGNUP_SUCCESS.getStatus())
                 .body(ApiResponse.success(MemberSuccessCode.SIGNUP_SUCCESS));
     }
@@ -76,6 +75,7 @@ public class MemberController implements MemberApiDocs{
         TokenGeneratedView result=generateTokenUseCase.generateToken(oneTimeToken);
         HeaderUtil.setAuthorizationHeader(response, result.accessToken());
         CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
+        CookieUtil.deleteCookie(response,"oneTimeToken");
         return ResponseEntity.status(MemberSuccessCode.TOKEN_GENERATED.getStatus())
                 .body(ApiResponse.success(MemberSuccessCode.TOKEN_GENERATED));
     }
@@ -110,7 +110,8 @@ public class MemberController implements MemberApiDocs{
     ) {
         String accessToken = AccessTokenResolver.resolve(request);
         logoutUseCase.logout(memberId,accessToken);
-        CookieUtil.deleteRefreshTokenCookie(response);
+        //CookieUtil.deleteRefreshTokenCookie(response);
+        CookieUtil.deleteCookie(response, "refreshToken");
         log.info("memberId: {}", memberId);
         return ResponseEntity.status(MemberSuccessCode.LOGOUT_SUCCESS.getStatus())
                 .body(ApiResponse.success(MemberSuccessCode.LOGOUT_SUCCESS));

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/util/CookieUtil.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/util/CookieUtil.java
@@ -31,8 +31,8 @@ public class CookieUtil {
         response.addHeader("Set-Cookie", cookie.toString());
     }
 
-    public static void deleteTempTokenCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from("tempToken", "")
+    public static void deleteCookie(HttpServletResponse response, String cookieName) {
+        ResponseCookie cookie = ResponseCookie.from(cookieName, "")
                 .path("/")
                 .maxAge(0)
                 .httpOnly(true)
@@ -40,17 +40,6 @@ public class CookieUtil {
                 .sameSite("None")
                 .build();
 
-        response.addHeader("Set-Cookie", cookie.toString());
-    }
-
-    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from("refreshToken","")
-                .path("/")
-                .maxAge(0)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .build();
         response.addHeader("Set-Cookie", cookie.toString());
     }
 }


### PR DESCRIPTION
## **🚀 Related issue**

closes #42 

## **#️⃣ Summary**

- 로그인,로그아웃,회원가입시 사용한 oneTimeToken, refreshToken, tempToken을 삭제하도록 처리하였습니다.

## **🎯 Work Description**

- [x] 쿠키삭제 로직 통합
- [x] 로그인 성공 시 oneTimeToken 삭제 로직 추가


## **👍 동작 확인**

- swagger나 postman 결과를 캡쳐하여 첨부

## **💬 To Reviewers**

- 리뷰어나 같이 작업하는 사람들에게 남길 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 쿠키 삭제 메커니즘을 최적화하여 더욱 효율적으로 처리되도록 개선했습니다. 로그인 후 일회용 토큰의 쿠키 정리가 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->