### PR TITLE
fix: refreshToken 없을 경우 500에러 해결

### DIFF
--- a/src/main/java/org/sopt/carena/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/carena/global/exception/handler/GlobalExceptionHandler.java
@@ -3,10 +3,12 @@ package org.sopt.carena.global.exception.handler;
 import org.sopt.carena.global.api.response.ApiResponse;
 import org.sopt.carena.global.exception.BaseException;
 import org.sopt.carena.global.exception.code.ErrorCode;
+import org.sopt.carena.member.exception.code.MemberErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
@@ -57,5 +59,10 @@ public class GlobalExceptionHandler extends BaseExceptionHandler {
 	protected ResponseEntity<ApiResponse> handleException(Exception e) {
 		// e.printStackTrace();
 		return buildErrorResponse(ErrorCode.UNDEFINED_ERROR);
+	}
+
+	@ExceptionHandler(MissingRequestCookieException.class)
+	protected ResponseEntity<ApiResponse> handleMissingRequestCookie(MissingRequestCookieException e) {
+		return buildErrorResponse(MemberErrorCode.NOT_EXIST_TOKEN);
 	}
 }

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
@@ -60,11 +60,11 @@ public class MemberController implements MemberApiDocs{
             @CookieValue(name = "refreshToken") final String refreshToken,
             HttpServletResponse response
     ) {
-        TokenGeneratedView result = refreshTokenUseCase.refreshAccessToken(refreshToken);
-        HeaderUtil.setAuthorizationHeader(response, result.accessToken());
-        CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
-        return ResponseEntity.status(MemberSuccessCode.TOKEN_REFRESHED.getStatus())
-                        .body(ApiResponse.success(MemberSuccessCode.TOKEN_REFRESHED));
+            TokenGeneratedView result = refreshTokenUseCase.refreshAccessToken(refreshToken);
+            HeaderUtil.setAuthorizationHeader(response, result.accessToken());
+            CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
+            return ResponseEntity.status(MemberSuccessCode.TOKEN_REFRESHED.getStatus())
+                    .body(ApiResponse.success(MemberSuccessCode.TOKEN_REFRESHED));
     }
 
     @PostMapping("/tokens")
@@ -72,12 +72,12 @@ public class MemberController implements MemberApiDocs{
             @CookieValue(name="oneTimeToken") final String oneTimeToken,
             HttpServletResponse response
     ) {
-        TokenGeneratedView result=generateTokenUseCase.generateToken(oneTimeToken);
-        HeaderUtil.setAuthorizationHeader(response, result.accessToken());
-        CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
-        CookieUtil.deleteCookie(response,"oneTimeToken");
-        return ResponseEntity.status(MemberSuccessCode.TOKEN_GENERATED.getStatus())
-                .body(ApiResponse.success(MemberSuccessCode.TOKEN_GENERATED));
+            TokenGeneratedView result = generateTokenUseCase.generateToken(oneTimeToken);
+            HeaderUtil.setAuthorizationHeader(response, result.accessToken());
+            CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
+            CookieUtil.deleteCookie(response, "oneTimeToken");
+            return ResponseEntity.status(MemberSuccessCode.TOKEN_GENERATED.getStatus())
+                    .body(ApiResponse.success(MemberSuccessCode.TOKEN_GENERATED));
     }
 
     @GetMapping("/my-page")
@@ -110,7 +110,6 @@ public class MemberController implements MemberApiDocs{
     ) {
         String accessToken = AccessTokenResolver.resolve(request);
         logoutUseCase.logout(memberId,accessToken);
-        //CookieUtil.deleteRefreshTokenCookie(response);
         CookieUtil.deleteCookie(response, "refreshToken");
         log.info("memberId: {}", memberId);
         return ResponseEntity.status(MemberSuccessCode.LOGOUT_SUCCESS.getStatus())

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/controller/MemberController.java
@@ -60,11 +60,11 @@ public class MemberController implements MemberApiDocs{
             @CookieValue(name = "refreshToken") final String refreshToken,
             HttpServletResponse response
     ) {
-            TokenGeneratedView result = refreshTokenUseCase.refreshAccessToken(refreshToken);
-            HeaderUtil.setAuthorizationHeader(response, result.accessToken());
-            CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
-            return ResponseEntity.status(MemberSuccessCode.TOKEN_REFRESHED.getStatus())
-                    .body(ApiResponse.success(MemberSuccessCode.TOKEN_REFRESHED));
+        TokenGeneratedView result = refreshTokenUseCase.refreshAccessToken(refreshToken);
+        HeaderUtil.setAuthorizationHeader(response, result.accessToken());
+        CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
+        return ResponseEntity.status(MemberSuccessCode.TOKEN_REFRESHED.getStatus())
+                .body(ApiResponse.success(MemberSuccessCode.TOKEN_REFRESHED));
     }
 
     @PostMapping("/tokens")
@@ -72,12 +72,12 @@ public class MemberController implements MemberApiDocs{
             @CookieValue(name="oneTimeToken") final String oneTimeToken,
             HttpServletResponse response
     ) {
-            TokenGeneratedView result = generateTokenUseCase.generateToken(oneTimeToken);
-            HeaderUtil.setAuthorizationHeader(response, result.accessToken());
-            CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
-            CookieUtil.deleteCookie(response, "oneTimeToken");
-            return ResponseEntity.status(MemberSuccessCode.TOKEN_GENERATED.getStatus())
-                    .body(ApiResponse.success(MemberSuccessCode.TOKEN_GENERATED));
+        TokenGeneratedView result = generateTokenUseCase.generateToken(oneTimeToken);
+        HeaderUtil.setAuthorizationHeader(response, result.accessToken());
+        CookieUtil.addRefreshTokenCookie(response, result.refreshToken());
+        CookieUtil.deleteCookie(response, "oneTimeToken");
+        return ResponseEntity.status(MemberSuccessCode.TOKEN_GENERATED.getStatus())
+                .body(ApiResponse.success(MemberSuccessCode.TOKEN_GENERATED));
     }
 
     @GetMapping("/my-page")

--- a/src/main/java/org/sopt/carena/member/adapter/in/web/dto/response/MemberInfoResponse.java
+++ b/src/main/java/org/sopt/carena/member/adapter/in/web/dto/response/MemberInfoResponse.java
@@ -11,16 +11,14 @@ public record MemberInfoResponse(
         String name,
         int age,
         Gender gender,
-        Long score,
-        LocalDate latestHealthCheckDate
+        Long score
 ) {
     public static MemberInfoResponse from(final MemberInfoView view) {
         return new MemberInfoResponse(
                 view.name(),
                 view.age(),
                 view.gender(),
-                view.score(),
-                view.latestHealthCheckDate()
+                view.score()
         );
     }
 }

--- a/src/main/java/org/sopt/carena/member/application/dto/view/MemberInfoView.java
+++ b/src/main/java/org/sopt/carena/member/application/dto/view/MemberInfoView.java
@@ -8,23 +8,19 @@ public record MemberInfoView(
         String name,
         int age,
         Gender gender,
-        Long score,
-        LocalDate latestHealthCheckDate
+        Long score
 ) {
     private MemberInfoView(
             String name,
             LocalDate birthdate,
             Gender gender,
-            Long score,
-            LocalDate latestHealthCheckDate
+            Long score
     ) {
         this(
                 name,
                 calculateAge(birthdate),
                 gender,
-                score,
-                latestHealthCheckDate
-
+                score
         );
     }
 
@@ -32,10 +28,9 @@ public record MemberInfoView(
             String name,
             LocalDate birthdate,
             Gender gender,
-            Long score,
-            LocalDate latestHealthCheckDate
+            Long score
     ) {
-        return new MemberInfoView(name, birthdate, gender, score, latestHealthCheckDate);
+        return new MemberInfoView(name, birthdate, gender, score);
     }
 
     private static int calculateAge(LocalDate birthdate) {

--- a/src/main/java/org/sopt/carena/member/application/service/MemberInfoService.java
+++ b/src/main/java/org/sopt/carena/member/application/service/MemberInfoService.java
@@ -2,20 +2,14 @@ package org.sopt.carena.member.application.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.carena.healthreport.application.port.out.HealthReportPersistencePort;
-import org.sopt.carena.healthreport.domain.HealthReport;
 import org.sopt.carena.member.application.dto.view.MemberInfoView;
 import org.sopt.carena.member.application.dto.view.MyPageInfoView;
 import org.sopt.carena.member.application.port.in.GetMemberInfoUseCase;
 import org.sopt.carena.member.application.port.out.MemberPersistencePort;
 import org.sopt.carena.member.domain.Member;
 import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
-import org.sopt.carena.recommend.application.port.out.LoadHealthReportPort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -24,24 +18,17 @@ import java.util.Optional;
 public class MemberInfoService implements GetMemberInfoUseCase {
 
     private final MemberPersistencePort memberPersistencePort;
-    private final LoadHealthReportPort loadHealthReportPort;
 
     @Override
     public MemberInfoView getMemberInfo(final Long memberId) {
         Member member = memberPersistencePort.getMemberById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
-        Optional<HealthReport> healthReport = loadHealthReportPort.findLatestHealthReportByMemberId(memberId);
-        LocalDate latestHealthCheckDate = healthReport
-                .map(HealthReport::getHealthCheckDate)
-                .orElse(null);
-
 
         return MemberInfoView.of(
                 member.getName(),
                 member.getBirthdate(),
                 member.getGender(),
-                member.getScore(),
-                latestHealthCheckDate
+                member.getScore()
         );
     }
     @Override

--- a/src/main/java/org/sopt/carena/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/org/sopt/carena/member/exception/code/MemberErrorCode.java
@@ -22,6 +22,7 @@ public enum MemberErrorCode implements ErrorResultCode {
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
     TOKEN_SIGNATURE_ERROR(HttpStatus.UNAUTHORIZED, "토큰 서명 검증에 실패했습니다."),
     EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다."),
+    NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED,"토큰값이 없습니다."),
     // OAuth
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth 제공자입니다."),
 

--- a/src/main/java/org/sopt/carena/member/exception/member/InvalidTempTokenException.java
+++ b/src/main/java/org/sopt/carena/member/exception/member/InvalidTempTokenException.java
@@ -7,8 +7,4 @@ public class InvalidTempTokenException extends BaseException {
     public InvalidTempTokenException() {
         super(MemberErrorCode.INVALID_TEMP_TOKEN);
     }
-
-    public InvalidTempTokenException(String message) {
-        super(MemberErrorCode.INVALID_TEMP_TOKEN, message);
-    }
 }


### PR DESCRIPTION
## **🚀 Related issue**

closes #44 

## **#️⃣ Summary**

- 토큰이 없을 때 401 이 아니라 500 이 뜨도록 해결

## **🎯 Work Description**

- [x] globalexceptionhandler에서 MissingRequestCookieException 처리하도록 추가
- [x] 토큰 없는 경우 errorcode추가
- [x] 불필요한 reponse 필드 삭제
- [x] 불필요한 import문 삭제

## **👍 동작 확인**

- swagger나 postman 결과를 캡쳐하여 첨부

<img width="601" height="621" alt="image" src="https://github.com/user-attachments/assets/f369ef3a-a957-4c73-834e-4336741b1b5f" />


## **💬 To Reviewers**

- 리뷰어나 같이 작업하는 사람들에게 남길 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 인증 토큰이 없을 때 명확한 오류 처리 및 권한 오류 응답 추가 (토큰 미존재 상황에 대한 처리 강화)

* **Refactor**
  * 회원 정보 응답에서 최근 건강검진 날짜 필드 제거 — 응답에 더 이상 건강검진 날짜가 포함되지 않음
  * 내부 예외 처리 정리 및 불필요 코드 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->