### PR TITLE
refactor: RAG 삽입 문서 단위를 Document 단위로 변경

### DIFF
--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/DietJpaPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/DietJpaPersistenceAdapter.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 public class DietJpaPersistenceAdapter implements DietPersistencePort {
 
     private final DietInformationJpaRepository infoRepository;
-    private final DietPersistenceMapper mapper;
     private final DietChunkJpaRepository dietChunkRepository;
 
     @Override
@@ -97,13 +96,13 @@ public class DietJpaPersistenceAdapter implements DietPersistencePort {
     @Transactional(readOnly = true)
     public Optional<DietInformation> loadById(final Long dietId) {
         return infoRepository.findById(dietId)
-                .map(mapper::toDomain);
+                .map(DietPersistenceMapper::toDomain);
     }
 
     @Override
     public Slice<DietInformation> loadDietList(final Pageable pageable) {
         return infoRepository.findAllByOrderByIdDesc(pageable)
-                .map(mapper::toDomain);
+                .map(DietPersistenceMapper::toDomain);
     }
     @Override
     public Slice<DietInformation> loadDietsByVectorSimilarity(final float[] embeddingVector, final int page, final int pageSize) {
@@ -140,7 +139,7 @@ public class DietJpaPersistenceAdapter implements DietPersistencePort {
         List<DietInformation> diets = dietIds.stream()
                 .map(dietEntityMap::get)
                 .filter(entity -> entity != null)
-                .map(mapper::toDomain)
+                .map(DietPersistenceMapper::toDomain)
                 .toList();
 
         log.debug("벡터 유사도 식단 조회 완료 - 결과: {}개, hasNext: {}", diets.size(), hasNext);

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/entity/DietInformationEntity.java
@@ -31,7 +31,6 @@ public class DietInformationEntity extends BaseEntity {
     @OneToMany(mappedBy = "document",cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<DietChunkEntity> chunks = new ArrayList<>();
 
-
     @OneToOne(mappedBy = "dietInformation",cascade = CascadeType.ALL, orphanRemoval = true)
     private RecommendedCategoryEntity recommendedFood;
 

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/mapper/DietPersistenceMapper.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/mapper/DietPersistenceMapper.java
@@ -6,7 +6,6 @@ import org.sopt.carena.diet.domain.DietInformation;
 import org.sopt.carena.diet.domain.value.CautionaryFoods;
 import org.sopt.carena.diet.domain.DietChunk;
 import org.sopt.carena.diet.domain.value.RecommendedFoods;
-import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
@@ -15,10 +14,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.LinkedHashMap;
 
-@Component
 public class DietPersistenceMapper {
 
-    public DietInformation toDomain(DietInformationEntity entity) {
+    public static DietInformation toDomain(DietInformationEntity entity) {
         return DietInformation.builder()
                 .id(entity.getId())
                 .title(entity.getTitle())
@@ -26,14 +24,14 @@ public class DietPersistenceMapper {
                 .reference(entity.getReference())
                 .referenceUrl(entity.getReferenceUrl())
                 .chunks(entity.getChunks().stream()
-                        .map(this::toDietChunk)
+                        .map(DietPersistenceMapper::toDietChunk)
                         .toList())
                 .recommendedFoods(toRecommendedFoods(entity))
                 .cautionaryFoods(toCautionaryFoods(entity))
                 .createdAt(entity.getCreatedAt())
                 .build();
     }
-    public DietChunk toDietChunk(DietChunkEntity chunkEntity) {
+    public static DietChunk toDietChunk(DietChunkEntity chunkEntity) {
         return DietChunk.builder()
                 .id(chunkEntity.getId())
                 .section(chunkEntity.getSection())
@@ -58,12 +56,12 @@ public class DietPersistenceMapper {
         return new CautionaryFoods(entity.getCautionaryFood().getCautionary());
     }
 
-    public Map<Long, DietInformation> toMapById(List<DietInformationEntity> entities) {
+    public static Map<Long, DietInformation> toMapById(List<DietInformationEntity> entities) {
         if (entities == null || entities.isEmpty()) {
             return Collections.emptyMap();
         }
         return entities.stream()
-                .map(this::toDomain)
+                .map(DietPersistenceMapper::toDomain)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toMap(
                         DietInformation::getId,

--- a/src/main/java/org/sopt/carena/diet/adapter/out/persistence/repository/DietInformationJpaRepository.java
+++ b/src/main/java/org/sopt/carena/diet/adapter/out/persistence/repository/DietInformationJpaRepository.java
@@ -31,5 +31,4 @@ public interface DietInformationJpaRepository extends JpaRepository<DietInformat
         """)
     List<DietInformationEntity> findAllByIdInWithDetails(@Param("ids") List<Long> ids);
 
-
 }

--- a/src/main/java/org/sopt/carena/diet/domain/DietInformation.java
+++ b/src/main/java/org/sopt/carena/diet/domain/DietInformation.java
@@ -8,6 +8,8 @@ import org.sopt.carena.diet.domain.value.RecommendedFoods;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Getter
 public class DietInformation {
@@ -44,5 +46,12 @@ public class DietInformation {
         this.recommendedFoods = recommendedFoods;
         this.cautionaryFoods = cautionaryFoods;
         this.createdAt = createdAt;
+    }
+
+    public String getCombinedChunkContent() {
+        return chunks.stream()
+                .map(DietChunk::getContent)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/org/sopt/carena/healthreport/application/converter/HealthReportEmbeddingConverter.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/converter/HealthReportEmbeddingConverter.java
@@ -9,7 +9,7 @@ import org.sopt.carena.healthreport.domain.status.RiskLevel;
 public class HealthReportEmbeddingConverter {
 	public static String toEmbeddingText(HealthReport healthReport) {
 		return healthReport.getStatusCarriers().stream()
-				.filter(carrier -> carrier.getRiskLevel() != RiskLevel.NONE)
+				.filter(carrier -> carrier.getRiskLevel() != RiskLevel.NONE && carrier.getRiskLevel() != RiskLevel.NORMAL)
 				.map(HealthStatusCarrier::getDescription)
 				.collect(Collectors.collectingAndThen(
 						Collectors.joining(", "),

--- a/src/main/java/org/sopt/carena/healthreport/application/port/out/GetRagResultPort.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/out/GetRagResultPort.java
@@ -3,8 +3,7 @@ package org.sopt.carena.healthreport.application.port.out;
 import java.util.List;
 
 import org.sopt.carena.infrastructure.llm.dto.RecommendedMealResult;
-import org.springframework.ai.document.Document;
 
 public interface GetRagResultPort {
-	RecommendedMealResult getRecommendedMeal(String embeddingText, List<Document> documents);
+	RecommendedMealResult getRecommendedMeal(String embeddingText, List<String> documentContents);
 }

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -52,7 +52,7 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 		healthScoreUseCase.updateMemberScore(member, healthReport);
 
         virtualExecutorService.submit(() -> embeddingAndSave(embeddingText, member, healthReport));
-        virtualExecutorService.submit(() -> createRecommendedMealUseCase.saveRagResult(member.getId()));
+		createRecommendedMealUseCase.saveRagResult(member.getId());
 	}
 
     private void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport) {

--- a/src/main/java/org/sopt/carena/infrastructure/llm/client/RagChatClient.java
+++ b/src/main/java/org/sopt/carena/infrastructure/llm/client/RagChatClient.java
@@ -1,13 +1,11 @@
 package org.sopt.carena.infrastructure.llm.client;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.sopt.carena.infrastructure.exception.LLMResultDeserializationException;
 import org.sopt.carena.infrastructure.llm.dto.RecommendMealPromptProperties;
 import org.sopt.carena.infrastructure.llm.dto.RecommendedMealResult;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,10 +23,10 @@ public class RagChatClient {
 	private final ChatClient chatClient;
 	private final ObjectMapper objectMapper;
 
-	public RecommendedMealResult getRecommendedMeal(String healthState, List<Document> documents) {
+	public RecommendedMealResult getRecommendedMeal(final String healthState, final List<String> documentContents) {
 		String systemPrompt = recommendMealPromptProperties.systemPrompt();
 
-		String userPrompt = buildUserPrompt(healthState, documents);
+		String userPrompt = buildUserPrompt(healthState, documentContents);
 
 		log.info("프롬프트 생성 성공, LLM 호출");
 
@@ -43,10 +41,8 @@ public class RagChatClient {
 		return parse(rawTextResponse);
 	}
 
-	private String buildUserPrompt(String healthState, List<Document> documents) {
-		String context = documents.stream()
-				.map(Document::getText)
-				.collect(Collectors.joining(LINE_SEPARATOR));
+	private String buildUserPrompt(String healthState, List<String> documentContents) {
+		String context = String.join(LINE_SEPARATOR, documentContents);
 
 		return recommendMealPromptProperties.userPrompt()
 				.replace("{healthState}", healthState)

--- a/src/main/java/org/sopt/carena/recommend/adapter/out/ai/RagChatAdapter.java
+++ b/src/main/java/org/sopt/carena/recommend/adapter/out/ai/RagChatAdapter.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.sopt.carena.healthreport.application.port.out.GetRagResultPort;
 import org.sopt.carena.infrastructure.llm.client.RagChatClient;
 import org.sopt.carena.infrastructure.llm.dto.RecommendedMealResult;
-import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -18,8 +17,8 @@ public class RagChatAdapter implements GetRagResultPort {
 	// 여기서 도메인 반환으로 변경
 	public RecommendedMealResult getRecommendedMeal(
 			final String embeddingText,
-			final List<Document> documents
+			final List<String> documentContents
 	) {
-		return ragChatClient.getRecommendedMeal(embeddingText, documents);
+		return ragChatClient.getRecommendedMeal(embeddingText, documentContents);
 	}
 }

--- a/src/main/java/org/sopt/carena/recommend/adapter/out/ai/VectorStoreAdapter.java
+++ b/src/main/java/org/sopt/carena/recommend/adapter/out/ai/VectorStoreAdapter.java
@@ -1,10 +1,12 @@
 package org.sopt.carena.recommend.adapter.out.ai;
 
-import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.sopt.carena.diet.adapter.out.persistence.mapper.DietPersistenceMapper;
+import org.sopt.carena.diet.adapter.out.persistence.repository.DietInformationJpaRepository;
+import org.sopt.carena.diet.domain.DietInformation;
 import org.sopt.carena.recommend.application.port.out.GetDocumentListPort;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
@@ -17,8 +19,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VectorStoreAdapter implements GetDocumentListPort {
 	private final VectorStore vectorStore;
+	private final DietInformationJpaRepository dietInformationRepository;
 
-	public List<Document> searchDocuments(final String embeddingText, final int limit) {
+	public List<DietInformation> searchDocumentsId(final String embeddingText, final int limit) {
 
 		List<Document> docs = vectorStore.similaritySearch(
 				SearchRequest.builder()
@@ -27,16 +30,17 @@ public class VectorStoreAdapter implements GetDocumentListPort {
 						.build()
 		);
 
-		return docs.stream()
-				.collect(Collectors.toMap(
-						d -> d.getMetadata().get("document_id"),
-						Function.identity(),
-						(existing, duplicate) -> existing,
-						LinkedHashMap::new
-				))
-				.values()
+		List<Long> documentIds = docs.stream()
+				.map(d -> (Long)d.getMetadata().get("document_id"))
+				.collect(Collectors.toCollection(LinkedHashSet::new))
 				.stream()
 				.limit(limit)
+				.toList();
+		System.out.println("===document id 추출===");
+		documentIds.forEach(id -> System.out.print(id+" "));
+
+		return dietInformationRepository.findAllByIdInWithDetails(documentIds).stream()
+				.map(DietPersistenceMapper::toDomain)
 				.toList();
 	}
 }

--- a/src/main/java/org/sopt/carena/recommend/adapter/out/ai/VectorStoreAdapter.java
+++ b/src/main/java/org/sopt/carena/recommend/adapter/out/ai/VectorStoreAdapter.java
@@ -36,8 +36,6 @@ public class VectorStoreAdapter implements GetDocumentListPort {
 				.stream()
 				.limit(limit)
 				.toList();
-		System.out.println("===document id 추출===");
-		documentIds.forEach(id -> System.out.print(id+" "));
 
 		return dietInformationRepository.findAllByIdInWithDetails(documentIds).stream()
 				.map(DietPersistenceMapper::toDomain)

--- a/src/main/java/org/sopt/carena/recommend/application/port/out/GetDocumentListPort.java
+++ b/src/main/java/org/sopt/carena/recommend/application/port/out/GetDocumentListPort.java
@@ -2,8 +2,8 @@ package org.sopt.carena.recommend.application.port.out;
 
 import java.util.List;
 
-import org.springframework.ai.document.Document;
+import org.sopt.carena.diet.domain.DietInformation;
 
 public interface GetDocumentListPort {
-	List<Document> searchDocuments(String embeddingText, int limit);
+	List<DietInformation> searchDocumentsId(String embeddingText, int limit);
 }

--- a/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
+++ b/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
@@ -53,32 +53,27 @@ public class CreateRecommendedMealService implements CreateRecommendedMealUseCas
 			final long memberId,
 			final long healthReportId
 	) {
-		try{
-			Long baseDocumentId = documents.getFirst().getId();
-			String baseDocumentTitle = documents.getFirst().getTitle();
+		Long baseDocumentId = documents.getFirst().getId();
+		String baseDocumentTitle = documents.getFirst().getTitle();
 
-			List<String> documentContents = documents.stream()
-					.map(DietInformation::getCombinedChunkContent)
-					.toList();
+		List<String> documentContents = documents.stream()
+				.map(DietInformation::getCombinedChunkContent)
+				.toList();
 
-			RecommendedMealResult result = getRagResultPort.getRecommendedMeal(embeddingText, documentContents);
+		RecommendedMealResult result = getRagResultPort.getRecommendedMeal(embeddingText, documentContents);
 
-			log.info("LLM 추천 식단 생성 완료, 저장 호출");
+		log.info("LLM 추천 식단 생성 완료, 저장 호출");
 
-			RecommendedMeal recommendedMeal = RecommendedMeal.builder()
-					.meal(result.meal())
-					.description(result.description())
-					.baseDocumentId(baseDocumentId)
-					.baseDocumentTitle(baseDocumentTitle)
-					.memberId(memberId)
-					.healthReportId(healthReportId)
-					.build();
+		RecommendedMeal recommendedMeal = RecommendedMeal.builder()
+				.meal(result.meal())
+				.description(result.description())
+				.baseDocumentId(baseDocumentId)
+				.baseDocumentTitle(baseDocumentTitle)
+				.memberId(memberId)
+				.healthReportId(healthReportId)
+				.build();
 
-			// rag 결과 저장
-			saveRecommendedMealPort.saveRecommendedMeal(recommendedMeal);
-		} catch (Exception e) {
-			e.printStackTrace();
-			// throw new RuntimeException(e);
-		}
+		// rag 결과 저장
+		saveRecommendedMealPort.saveRecommendedMeal(recommendedMeal);
 	}
 }

--- a/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
+++ b/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
@@ -42,7 +42,6 @@ public class CreateRecommendedMealService implements CreateRecommendedMealUseCas
 			throw new DocumentNotExistException();
 		}
 
-		System.out.println("===식단 추천 시작===");
 		virtualExecutorService.submit(
 				() -> saveRagResultAsync(embeddingText, documents, memberId, healthReport.getId()));
 	}

--- a/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
+++ b/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
@@ -3,6 +3,7 @@ package org.sopt.carena.recommend.application.service;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import org.sopt.carena.diet.domain.DietInformation;
 import org.sopt.carena.healthreport.application.converter.HealthReportEmbeddingConverter;
 import org.sopt.carena.healthreport.application.port.out.GetRagResultPort;
 import org.sopt.carena.healthreport.application.port.out.SaveRecommendedMealPort;
@@ -14,7 +15,6 @@ import org.sopt.carena.recommend.application.port.out.GetDocumentListPort;
 import org.sopt.carena.recommend.application.port.out.LoadHealthReportPort;
 import org.sopt.carena.recommend.domain.RecommendedMeal;
 import org.sopt.carena.recommend.exception.DocumentNotExistException;
-import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -36,39 +36,49 @@ public class CreateRecommendedMealService implements CreateRecommendedMealUseCas
 
 		String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);
 
-		List<Document> documents = getDocumentListPort.searchDocuments(embeddingText, 5);
+		List<DietInformation> documents = getDocumentListPort.searchDocumentsId(embeddingText, 5);
 
 		if (documents.isEmpty()) {
 			throw new DocumentNotExistException();
 		}
 
+		System.out.println("===식단 추천 시작===");
 		virtualExecutorService.submit(
 				() -> saveRagResultAsync(embeddingText, documents, memberId, healthReport.getId()));
 	}
 
 	private void saveRagResultAsync(
 			final String embeddingText,
-			final List<Document> documents,
+			final List<DietInformation> documents,
 			final long memberId,
 			final long healthReportId
 	) {
-		Long baseDocumentId = (Long)documents.get(0).getMetadata().get("document_id");
-		String baseDocumentTitle = (String)documents.get(0).getMetadata().get("title");
+		try{
+			Long baseDocumentId = documents.getFirst().getId();
+			String baseDocumentTitle = documents.getFirst().getTitle();
 
-		RecommendedMealResult result = getRagResultPort.getRecommendedMeal(embeddingText, documents);
+			List<String> documentContents = documents.stream()
+					.map(DietInformation::getCombinedChunkContent)
+					.toList();
 
-		log.info("LLM 추천 식단 생성 완료, 저장 호출");
+			RecommendedMealResult result = getRagResultPort.getRecommendedMeal(embeddingText, documentContents);
 
-		RecommendedMeal recommendedMeal = RecommendedMeal.builder()
-				.meal(result.meal())
-				.description(result.description())
-				.baseDocumentId(baseDocumentId)
-				.baseDocumentTitle(baseDocumentTitle)
-				.memberId(memberId)
-				.healthReportId(healthReportId)
-				.build();
+			log.info("LLM 추천 식단 생성 완료, 저장 호출");
 
-		// rag 결과 저장
-		saveRecommendedMealPort.saveRecommendedMeal(recommendedMeal);
+			RecommendedMeal recommendedMeal = RecommendedMeal.builder()
+					.meal(result.meal())
+					.description(result.description())
+					.baseDocumentId(baseDocumentId)
+					.baseDocumentTitle(baseDocumentTitle)
+					.memberId(memberId)
+					.healthReportId(healthReportId)
+					.build();
+
+			// rag 결과 저장
+			saveRecommendedMealPort.saveRecommendedMeal(recommendedMeal);
+		} catch (Exception e) {
+			e.printStackTrace();
+			// throw new RuntimeException(e);
+		}
 	}
 }


### PR DESCRIPTION
## **🚀 Related issue**

closes #46 

## **#️⃣ Summary**

- 식단 추천 결과의 정확도를 높이기 위해 RAG를 이용한 식단 추천 과정에서 삽입되는 식단 정보 문서의 단위를 chunk에서 document 단위로 변경합니다.

## **🎯 Work Description**

- [x] RAG 삽입 문서 단위를 chunk에서 document로 변경

## **👍 동작 확인**

- document 단위 데이터의 프롬프트 삽입 결과
  <img width="1542" height="667" alt="스크린샷 2026-01-22 오후 5 54 49" src="https://github.com/user-attachments/assets/da78e700-ea16-4221-9a5b-1062fe8197c3" />

## **💬 To Reviewers**

- LLM이 결과 생성에 참고하는 문서의 양을 늘리기 위해 기존의 chunk단위 삽입에서 document단위 삽입으로 변경하였습니다.
- 테스트 결과, 추후 식단 정보 문서와 사용자 상태에 대한 라벨링을 추가하면 좋을 것 같기도 합니다...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 내부 매핑 로직을 정리하고 문서 흐름을 단순화하여 유지보수성을 개선했습니다.
  * 벡터 검색 결과 처리 흐름을 변경해 식단 ID로 상세 정보를 조회하도록 개선했습니다.

* **New Features**
  * 식단 조각 내용을 합쳐 보여주는 결합 텍스트를 제공하여 추천 입력으로 활용합니다.
  * 검색 결과가 더 풍부한 식단 정보 목록으로 반환됩니다.

* **Behavior Change**
  * 추천 생성 결과 저장이 즉시 실행되어 처리 시점이 변경됩니다.
  * 건강 리포트 입력에서 정상(NORMAL) 상태를 제외하도록 필터링을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->