### PR TITLE
refactor: 외부 API 호출 재시도 로직 추가

### DIFF
--- a/src/main/java/org/sopt/carena/CarenaApplication.java
+++ b/src/main/java/org/sopt/carena/CarenaApplication.java
@@ -3,7 +3,9 @@ package org.sopt.carena;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class CarenaApplication {

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -3,6 +3,7 @@ package org.sopt.carena.healthreport.application.service;
 import java.util.concurrent.ExecutorService;
 
 import org.sopt.carena.diet.application.port.out.EmbeddingPort;
+import org.sopt.carena.diet.exception.embedding.EmbeddingFailedException;
 import org.sopt.carena.healthreport.application.converter.HealthReportEmbeddingConverter;
 import org.sopt.carena.healthreport.application.dto.command.CreateHealthReportCommand;
 import org.sopt.carena.healthreport.application.port.in.CreateHealthReportUseCase;
@@ -17,10 +18,15 @@ import org.sopt.carena.member.domain.Member;
 
 import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
 import org.sopt.carena.recommend.application.port.in.CreateRecommendedMealUseCase;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CreateHealthReportService implements CreateHealthReportUseCase {
@@ -55,6 +61,12 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 		createRecommendedMealUseCase.saveRagResult(member.getId());
 	}
 
+	@Retryable(
+			retryFor = EmbeddingFailedException.class,
+			maxAttempts = 3,
+			backoff = @Backoff(delay = 5000, multiplier = 2),
+			recover = "recoverEmbedding"
+	)
     private void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport) {
         // 임베딩 호출
         float[] embedding = embeddingPort.embed(embeddingText).vector();
@@ -70,4 +82,9 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
         // 임베딩 결과 저장
         healthReportEmbeddingPersistencePort.saveHealthReportEmbedding(healthReportEmbedding);
     }
+
+	@Recover
+	public void recoverEmbedding(final EmbeddingFailedException e, final Member member, final HealthReport healthReport){
+		log.error("임베딩 실패: {}",e.getMessage());
+	}
 }

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -67,7 +67,7 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 			backoff = @Backoff(delay = 5000, multiplier = 2),
 			recover = "recoverEmbedding"
 	)
-    private void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport) {
+    public void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport) {
         // 임베딩 호출
         float[] embedding = embeddingPort.embed(embeddingText).vector();
 
@@ -84,7 +84,12 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
     }
 
 	@Recover
-	public void recoverEmbedding(final EmbeddingFailedException e, final Member member, final HealthReport healthReport){
+	public void recoverEmbedding(
+			final EmbeddingFailedException e,
+			final String embeddingText,
+			final Member member,
+			final HealthReport healthReport
+	){
 		log.error("임베딩 실패: {}",e.getMessage());
 	}
 }

--- a/src/main/java/org/sopt/carena/healthreport/application/service/ExtractTextFromImageService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/ExtractTextFromImageService.java
@@ -24,14 +24,15 @@ public class ExtractTextFromImageService implements ExtractTextFromImageUseCase 
 			retryFor = OcrApiFailException.class,
 			maxAttempts = 3,
 			backoff = @Backoff(delay = 5000, multiplier = 2),
-			recover = "recoverEmbedding"
+			recover = "recoverOcrApi"
 	)
 	public ExtractedTextView extractTextFromImage(final ExtractTextCommand command) {
 		return OcrHealthReportParser.parse(ocrPort.extractText(command));
 	}
 
 	@Recover
-	public void recoverOcrApi(final OcrApiFailException e, final ExtractTextCommand command) {
+	public ExtractedTextView recoverOcrApi(final OcrApiFailException e, final ExtractTextCommand command) {
 		log.error(e.getMessage());
+		throw e;
 	}
 }

--- a/src/main/java/org/sopt/carena/healthreport/application/service/ExtractTextFromImageService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/ExtractTextFromImageService.java
@@ -5,16 +5,33 @@ import org.sopt.carena.healthreport.application.dto.view.ExtractedTextView;
 import org.sopt.carena.healthreport.application.port.in.ExtractTextFromImageUseCase;
 import org.sopt.carena.healthreport.application.port.out.OcrPort;
 import org.sopt.carena.healthreport.application.parser.OcrHealthReportParser;
+import org.sopt.carena.healthreport.exception.ocr.OcrApiFailException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ExtractTextFromImageService implements ExtractTextFromImageUseCase {
 	private final OcrPort ocrPort;
 
+	@Retryable(
+			retryFor = OcrApiFailException.class,
+			maxAttempts = 3,
+			backoff = @Backoff(delay = 5000, multiplier = 2),
+			recover = "recoverEmbedding"
+	)
 	public ExtractedTextView extractTextFromImage(final ExtractTextCommand command) {
 		return OcrHealthReportParser.parse(ocrPort.extractText(command));
+	}
+
+	@Recover
+	public void recoverOcrApi(final OcrApiFailException e, final ExtractTextCommand command) {
+		log.error(e.getMessage());
 	}
 }

--- a/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
+++ b/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
@@ -15,6 +15,9 @@ import org.sopt.carena.recommend.application.port.out.GetDocumentListPort;
 import org.sopt.carena.recommend.application.port.out.LoadHealthReportPort;
 import org.sopt.carena.recommend.domain.RecommendedMeal;
 import org.sopt.carena.recommend.exception.DocumentNotExistException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -46,6 +49,12 @@ public class CreateRecommendedMealService implements CreateRecommendedMealUseCas
 				() -> saveRagResultAsync(embeddingText, documents, memberId, healthReport.getId()));
 	}
 
+	@Retryable(
+			retryFor = Exception.class,
+			maxAttempts = 3,
+			backoff = @Backoff(delay = 5000, multiplier = 2),
+			recover = "recoverRecommendMeal"
+	)
 	private void saveRagResultAsync(
 			final String embeddingText,
 			final List<DietInformation> documents,
@@ -74,5 +83,16 @@ public class CreateRecommendedMealService implements CreateRecommendedMealUseCas
 
 		// rag 결과 저장
 		saveRecommendedMealPort.saveRecommendedMeal(recommendedMeal);
+	}
+
+	@Recover
+	public void recoverRecommendMeal(
+			final Exception e,
+			final String embeddingText,
+			final List<DietInformation> documents,
+			final long memberId,
+			final long healthReportId
+	) {
+		log.error("LLM 호출 실패: {}", e.getMessage());
 	}
 }

--- a/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
+++ b/src/main/java/org/sopt/carena/recommend/application/service/CreateRecommendedMealService.java
@@ -55,7 +55,7 @@ public class CreateRecommendedMealService implements CreateRecommendedMealUseCas
 			backoff = @Backoff(delay = 5000, multiplier = 2),
 			recover = "recoverRecommendMeal"
 	)
-	private void saveRagResultAsync(
+	public void saveRagResultAsync(
 			final String embeddingText,
 			final List<DietInformation> documents,
 			final long memberId,


### PR DESCRIPTION
## **🚀 Related issue**

closes #48 

## **#️⃣ Summary**

- 임베딩 및 LLM, OCR API호출에서의 재시도 로직을 추가합니다.

## **🎯 Work Description**

- [x] 임베딩 API 호출에 재시도 로직 추가
- [x] LLM 호출에 재시도 로직 추가
- [x] OCR API 호출에 재시도 로직 추가

## **👍 동작 확인**

- 리팩토링이므로 생략합니다!

## **💬 To Reviewers**

- 현재 `@Recover`에서 간단한 로그 출력만 하도록 조치했지만 추후 논의를 통해 로그 수집이나 이벤트 발생 등의 내용을 추가하면 좋을 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 임베딩 처리에 자동 재시도와 복구 경로를 추가해 건강 리포트 생성 안정성을 향상했습니다.
  * OCR 기반 이미지 텍스트 추출에 재시도 및 복구 로직을 도입해 실패 복원력을 높였습니다.
  * 식단 추천 생성 흐름에 재시도와 복구 로깅을 추가해 신뢰성을 강화했습니다.
  * 전체 애플리케이션에 재시도 기능을 활성화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->