### PR TITLE
feat: 검진기관 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ repositories {
 dependencies {
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/org/sopt/carena/global/config/WebClientConfig.java
+++ b/src/main/java/org/sopt/carena/global/config/WebClientConfig.java
@@ -5,8 +5,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
@@ -33,8 +38,14 @@ public class WebClientConfig {
 						.addHandlerLast(new WriteTimeoutHandler(10000, TimeUnit.MILLISECONDS))
 				);
 
+		XmlMapper xmlMapper = new XmlMapper();
+		xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
 		return WebClient.builder()
 				.clientConnector(new ReactorClientHttpConnector(httpClient))
+				.codecs(configurer -> configurer
+						.customCodecs()
+						.register(new Jackson2JsonDecoder(xmlMapper, MediaType.APPLICATION_XML)))
 				.build();
 	}
 }

--- a/src/main/java/org/sopt/carena/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/carena/global/exception/handler/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
@@ -33,8 +34,7 @@ public class GlobalExceptionHandler extends BaseExceptionHandler {
 	}
 
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
-	protected ResponseEntity<ApiResponse> handleMethodArgumentTypeMismatchException(
-			MethodArgumentTypeMismatchException e) {
+	protected ResponseEntity<ApiResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
 		return buildErrorResponse(ErrorCode.INVALID_REQUEST_MESSAGE);
 	}
 
@@ -54,8 +54,7 @@ public class GlobalExceptionHandler extends BaseExceptionHandler {
 	}
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	protected ResponseEntity<ApiResponse> handleHttpRequestMethodNotSupportedException(
-			HttpRequestMethodNotSupportedException e) {
+	protected ResponseEntity<ApiResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
 		return buildErrorResponse(ErrorCode.INVALID_REQUEST_METHOD);
 	}
 
@@ -65,7 +64,12 @@ public class GlobalExceptionHandler extends BaseExceptionHandler {
 	}
 
 	@ExceptionHandler(MissingServletRequestPartException.class)
-	protected ResponseEntity<ApiResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e){
+	protected ResponseEntity<ApiResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+		return buildErrorResponse(ErrorCode.INVALID_REQUEST_MESSAGE);
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	protected ResponseEntity<ApiResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
 		return buildErrorResponse(ErrorCode.INVALID_REQUEST_MESSAGE);
 	}
 

--- a/src/main/java/org/sopt/carena/infrastructure/publicdata/client/PublicDataClient.java
+++ b/src/main/java/org/sopt/carena/infrastructure/publicdata/client/PublicDataClient.java
@@ -1,0 +1,72 @@
+package org.sopt.carena.infrastructure.publicdata.client;
+
+import org.sopt.carena.infrastructure.publicdata.dto.SidoCodeResponse;
+import org.sopt.carena.infrastructure.publicdata.dto.SigunguCodeResponse;
+import org.sopt.carena.institution.exception.PublicDataAccessFailException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PublicDataClient {
+	private static final int numOfPage = 10;
+	@Value("${public-data.base-url}")
+	private String baseUrl;
+
+	@Value("${public-data.path.address-code.sido}")
+	private String sidoCodeRequestPath;
+
+	@Value("${public-data.path.address-code.sigungu}")
+	private String sigunguRequestPath;
+
+	@Value("${public-data.path.institution}")
+	private String institutionRequestPath;
+
+	@Value("${public-data.secret-key}")
+	private String apiKey;
+
+	private final WebClient webClient;
+
+	// 전체 18개
+	public SidoCodeResponse getSidoCode() {
+		try{
+			return webClient.get()
+					.uri(uriBuilder -> uriBuilder
+							.scheme("https")
+							.host(baseUrl)
+							.path(sidoCodeRequestPath)
+							.queryParam("serviceKey", apiKey)
+							.queryParam("numOfRows", 20)
+							.build())
+					.retrieve()
+					.bodyToMono(SidoCodeResponse.class).block();
+
+		} catch (Exception e) {
+			throw new PublicDataAccessFailException();
+		}
+	}
+
+	public SigunguCodeResponse getSigunguCode(final int sidoCode){
+		try{
+			return webClient.get()
+					.uri(uriBuilder -> uriBuilder
+							.scheme("https")
+							.host(baseUrl)
+							.path(sigunguRequestPath)
+							.queryParam("serviceKey", apiKey)
+							.queryParam("siDoCd", sidoCode)
+							.queryParam("numOfRows", 45)
+							.build()
+					)
+					.retrieve()
+					.bodyToMono(SigunguCodeResponse.class).block();
+		} catch (Exception e) {
+			throw new PublicDataAccessFailException();
+		}
+	}
+}

--- a/src/main/java/org/sopt/carena/infrastructure/publicdata/client/PublicDataClient.java
+++ b/src/main/java/org/sopt/carena/infrastructure/publicdata/client/PublicDataClient.java
@@ -1,5 +1,6 @@
 package org.sopt.carena.infrastructure.publicdata.client;
 
+import org.sopt.carena.infrastructure.publicdata.dto.InstitutionInfoResponse;
 import org.sopt.carena.infrastructure.publicdata.dto.SidoCodeResponse;
 import org.sopt.carena.infrastructure.publicdata.dto.SigunguCodeResponse;
 import org.sopt.carena.institution.exception.PublicDataAccessFailException;
@@ -34,7 +35,7 @@ public class PublicDataClient {
 
 	// 전체 18개
 	public SidoCodeResponse getSidoCode() {
-		try{
+		try {
 			return webClient.get()
 					.uri(uriBuilder -> uriBuilder
 							.scheme("https")
@@ -51,8 +52,9 @@ public class PublicDataClient {
 		}
 	}
 
-	public SigunguCodeResponse getSigunguCode(final int sidoCode){
-		try{
+	// 전체 45개
+	public SigunguCodeResponse getSigunguCode(final int sidoCode) {
+		try {
 			return webClient.get()
 					.uri(uriBuilder -> uriBuilder
 							.scheme("https")
@@ -65,6 +67,35 @@ public class PublicDataClient {
 					)
 					.retrieve()
 					.bodyToMono(SigunguCodeResponse.class).block();
+		} catch (Exception e) {
+			throw new PublicDataAccessFailException();
+		}
+	}
+
+	public InstitutionInfoResponse getInstitutionInfo(
+			final int page,
+			final Integer sidoCode,
+			final Integer sigunguCode,
+			final int type,
+			final String institutionName
+	) {
+		try {
+			return webClient.get()
+					.uri(uriBuilder -> uriBuilder
+							.scheme("https")
+							.host(baseUrl)
+							.path(institutionRequestPath)
+							.queryParam("serviceKey", apiKey)
+							.queryParam("pageNo", page)
+							.queryParam("numOfRows", 20)
+							.queryParam("siDoCd", sidoCode)
+							.queryParam("siGunGuCd", sigunguCode)
+							.queryParam("hchType", type)
+							.queryParam("hmcNm", institutionName)
+							.build()
+					)
+					.retrieve()
+					.bodyToMono(InstitutionInfoResponse.class).block();
 		} catch (Exception e) {
 			throw new PublicDataAccessFailException();
 		}

--- a/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/InstitutionInfoResponse.java
+++ b/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/InstitutionInfoResponse.java
@@ -1,0 +1,40 @@
+package org.sopt.carena.infrastructure.publicdata.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+public record InstitutionInfoResponse(
+		Body body
+) {
+	public record Body(
+			Items items,
+			int numOfRows,
+			int pageNo,
+			int totalCount
+	) {}
+
+	public record Items(
+			@JacksonXmlElementWrapper(useWrapping = false)
+			@JacksonXmlProperty(localName = "item")
+			List<Item> item
+	) {}
+
+	// 검진 담당 구분 코드가 1인 경우 해당, 0인 경우 비해당
+	public record Item(
+			int bcExmdChrgTypeCd,	// 유방암검진담당구분코드
+			int ccExmdChrgTypeCd,	// 대장암검진담당구분코드
+			int cvxcaExmdChrgTypeCd,	// 자궁경부암검진담당구분코드
+			double cxVl,	// 경도 좌표
+			double cyVl,	// 위도 좌표
+			int grenChrgTypeCd,		// 일반검진담당구분코드
+			String hmcNm,	// 이름
+			String hmcNo,	// 고유 번호(식별자)
+			int ichkChrgTypeCd,		// 영유아검진담당구분코드
+			String locAddr,	// 주소
+			int lvcaExmdChrgTypeCd,	// 간암검진담당구분코드
+			int mchkChrgTypeCd,		// 구강검진담당구분코드
+			int stmcaExmdChrgTypeCd	// 위암검진담당구분코드
+	) {}
+}

--- a/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/InstitutionInfoResponse.java
+++ b/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/InstitutionInfoResponse.java
@@ -23,18 +23,18 @@ public record InstitutionInfoResponse(
 
 	// 검진 담당 구분 코드가 1인 경우 해당, 0인 경우 비해당
 	public record Item(
-			int bcExmdChrgTypeCd,	// 유방암검진담당구분코드
-			int ccExmdChrgTypeCd,	// 대장암검진담당구분코드
-			int cvxcaExmdChrgTypeCd,	// 자궁경부암검진담당구분코드
-			double cxVl,	// 경도 좌표
-			double cyVl,	// 위도 좌표
-			int grenChrgTypeCd,		// 일반검진담당구분코드
+			Integer bcExmdChrgTypeCd,	// 유방암검진담당구분코드
+			Integer ccExmdChrgTypeCd,	// 대장암검진담당구분코드
+			Integer cvxcaExmdChrgTypeCd,	// 자궁경부암검진담당구분코드
+			Double cxVl,	// 경도 좌표
+			Double cyVl,	// 위도 좌표
+			Integer grenChrgTypeCd,		// 일반검진담당구분코드
 			String hmcNm,	// 이름
 			String hmcNo,	// 고유 번호(식별자)
-			int ichkChrgTypeCd,		// 영유아검진담당구분코드
+			Integer ichkChrgTypeCd,		// 영유아검진담당구분코드
 			String locAddr,	// 주소
-			int lvcaExmdChrgTypeCd,	// 간암검진담당구분코드
-			int mchkChrgTypeCd,		// 구강검진담당구분코드
-			int stmcaExmdChrgTypeCd	// 위암검진담당구분코드
+			Integer lvcaExmdChrgTypeCd,	// 간암검진담당구분코드
+			Integer mchkChrgTypeCd,		// 구강검진담당구분코드
+			Integer stmcaExmdChrgTypeCd	// 위암검진담당구분코드
 	) {}
 }

--- a/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/SidoCodeResponse.java
+++ b/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/SidoCodeResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.carena.infrastructure.publicdata.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+public record SidoCodeResponse(
+		Body body
+) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Body(
+			Items items,
+			int pageNo,
+			int totalCount
+	) {}
+
+	public record Items(
+			@JacksonXmlElementWrapper(useWrapping = false)
+			@JacksonXmlProperty(localName = "item")
+			List<Item> item
+	) {}
+
+	public record Item(
+			String siDoNm,
+			int siDoCd
+	) {}
+}

--- a/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/SigunguCodeResponse.java
+++ b/src/main/java/org/sopt/carena/infrastructure/publicdata/dto/SigunguCodeResponse.java
@@ -1,0 +1,30 @@
+package org.sopt.carena.infrastructure.publicdata.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+public record SigunguCodeResponse(
+		Body body
+) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Body(
+			Items items,
+			int pageNo,
+			int totalCount
+	) {}
+
+	public record Items(
+			@JacksonXmlElementWrapper(useWrapping = false)
+			@JacksonXmlProperty(localName = "item")
+			List<Item> item
+	) {}
+
+	public record Item(
+			String siGunGuNm,
+			int siDoCd,
+			int siGunGuCd
+	) {}
+}

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/code/SuccessCode.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/code/SuccessCode.java
@@ -1,0 +1,17 @@
+package org.sopt.carena.institution.adapter.in.web.code;
+
+import org.sopt.carena.global.api.code.SuccessResultCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode implements SuccessResultCode {
+	ADDRESS_CODE_FOUND(HttpStatus.OK, "주소 코드 조회가 완료되었습니다."),
+	INSTITUTION_FOUND(HttpStatus.OK, "검진 기관 조회가 완료되었습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionApiDocs.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionApiDocs.java
@@ -1,0 +1,21 @@
+package org.sopt.carena.institution.adapter.in.web.controller;
+
+import org.sopt.carena.global.api.response.SuccessResponse;
+import org.sopt.carena.institution.application.dto.view.InstitutionListView;
+import org.sopt.carena.institution.application.dto.view.SidoCodeView;
+import org.sopt.carena.institution.application.dto.view.SigunguCodeView;
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+@Tag(name = "건강검진 기관", description = "건강 검진 기관 조회 관련 API")
+public interface InstitutionApiDocs {
+	@Operation(summary = "시/도 주소 코드 조회", description = "검진 기관 검색에 필요한 시/도 단위의 주소 코드 목록을 조회합니다.")
+	ResponseEntity<SuccessResponse<SidoCodeView>> getSidoCode();
+
+	@Operation(summary = "시/군/구 주소 코드 조회", description = "시/도 단위 주소 코드에 포함되는 시/군/구 단위의 주소 코드 목록을 조회합니다.")
+	ResponseEntity<SuccessResponse<SigunguCodeView>> getSigunguCode(int sidoCode);
+}

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionApiDocs.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionApiDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 @Tag(name = "건강검진 기관", description = "건강 검진 기관 조회 관련 API")
 public interface InstitutionApiDocs {
@@ -17,7 +18,7 @@ public interface InstitutionApiDocs {
 	ResponseEntity<SuccessResponse<SidoCodeView>> getSidoCode();
 
 	@Operation(summary = "시/군/구 주소 코드 조회", description = "시/도 단위 주소 코드에 포함되는 시/군/구 단위의 주소 코드 목록을 조회합니다.")
-	ResponseEntity<SuccessResponse<SigunguCodeView>> getSigunguCode(int sidoCode);
+	ResponseEntity<SuccessResponse<SigunguCodeView>> getSigunguCode(@NotNull int sidoCode);
 
 	@Operation(summary = "건강검진 기관 조회", description = "검색 파라미터 조건에 해당하는 건강검진 기관 목록을 조회합니다.")
 	ResponseEntity<SuccessResponse<InstitutionListView>> getInstitutionInfo(@Min(1) int page, Integer sidoCode, Integer sigunguCode, @Min(0) @Max(6) int type, String name);

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionApiDocs.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionApiDocs.java
@@ -18,4 +18,7 @@ public interface InstitutionApiDocs {
 
 	@Operation(summary = "시/군/구 주소 코드 조회", description = "시/도 단위 주소 코드에 포함되는 시/군/구 단위의 주소 코드 목록을 조회합니다.")
 	ResponseEntity<SuccessResponse<SigunguCodeView>> getSigunguCode(int sidoCode);
+
+	@Operation(summary = "건강검진 기관 조회", description = "검색 파라미터 조건에 해당하는 건강검진 기관 목록을 조회합니다.")
+	ResponseEntity<SuccessResponse<InstitutionListView>> getInstitutionInfo(@Min(1) int page, Integer sidoCode, Integer sigunguCode, @Min(0) @Max(6) int type, String name);
 }

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionController.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -33,7 +34,7 @@ public class InstitutionController implements InstitutionApiDocs {
 
 	@GetMapping(path = "/sigungu-code")
 	public ResponseEntity<SuccessResponse<SigunguCodeView>> getSigunguCode(
-			@RequestParam(name = "sidoCode") final int sidoCode
+			@RequestParam(name = "sidoCode") @NotNull final int sidoCode
 	) {
 		return ResponseEntity.status(SuccessCode.ADDRESS_CODE_FOUND.getStatus())
 				.body(ApiResponse.success(SuccessCode.ADDRESS_CODE_FOUND,

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionController.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionController.java
@@ -39,4 +39,17 @@ public class InstitutionController implements InstitutionApiDocs {
 				.body(ApiResponse.success(SuccessCode.ADDRESS_CODE_FOUND,
 						getAddressCodeUseCase.getSigunguCodes(sidoCode)));
 	}
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<InstitutionListView>> getInstitutionInfo(
+			@RequestParam(name = "page", defaultValue = "1") @Min(1) final int page,
+			@RequestParam(name = "sidoCode", required = false) final Integer sidoCode,
+			@RequestParam(name = "sigunguCode", required = false) final Integer sigunguCode,
+			@RequestParam(name = "type", defaultValue = "0") @Min(0) @Max(6) final int type,
+			@RequestParam(name = "name", required = false) final String name
+	) {
+		return ResponseEntity.status(SuccessCode.INSTITUTION_FOUND.getStatus())
+				.body(ApiResponse.success(SuccessCode.INSTITUTION_FOUND,
+						getInstitutionInfoUseCase.searchInstitution(page, sidoCode, sigunguCode, type, name)));
+	}
 }

--- a/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionController.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/in/web/controller/InstitutionController.java
@@ -1,0 +1,42 @@
+package org.sopt.carena.institution.adapter.in.web.controller;
+
+import org.sopt.carena.global.api.response.ApiResponse;
+import org.sopt.carena.global.api.response.SuccessResponse;
+import org.sopt.carena.institution.adapter.in.web.code.SuccessCode;
+import org.sopt.carena.institution.application.dto.view.InstitutionListView;
+import org.sopt.carena.institution.application.dto.view.SidoCodeView;
+import org.sopt.carena.institution.application.dto.view.SigunguCodeView;
+import org.sopt.carena.institution.application.port.in.GetAddressCodeUseCase;
+import org.sopt.carena.institution.application.port.in.GetInstitutionInfoUseCase;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/v1/institution")
+public class InstitutionController implements InstitutionApiDocs {
+	private final GetAddressCodeUseCase getAddressCodeUseCase;
+	private final GetInstitutionInfoUseCase getInstitutionInfoUseCase;
+
+	@GetMapping(path = "/sido-code")
+	public ResponseEntity<SuccessResponse<SidoCodeView>> getSidoCode() {
+		return ResponseEntity.status(SuccessCode.ADDRESS_CODE_FOUND.getStatus())
+				.body(ApiResponse.success(SuccessCode.ADDRESS_CODE_FOUND, getAddressCodeUseCase.getSidoCodes()));
+	}
+
+	@GetMapping(path = "/sigungu-code")
+	public ResponseEntity<SuccessResponse<SigunguCodeView>> getSigunguCode(
+			@RequestParam(name = "sidoCode") final int sidoCode
+	) {
+		return ResponseEntity.status(SuccessCode.ADDRESS_CODE_FOUND.getStatus())
+				.body(ApiResponse.success(SuccessCode.ADDRESS_CODE_FOUND,
+						getAddressCodeUseCase.getSigunguCodes(sidoCode)));
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/PublicDataAdapter.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/PublicDataAdapter.java
@@ -1,0 +1,29 @@
+package org.sopt.carena.institution.adapter.out.web.publicdata;
+
+import java.util.List;
+
+import org.sopt.carena.infrastructure.publicdata.client.PublicDataClient;
+import org.sopt.carena.institution.adapter.out.web.publicdata.mapper.AddressCodeMapper;
+import org.sopt.carena.institution.adapter.out.web.publicdata.mapper.InstitutionInfoMapper;
+import org.sopt.carena.institution.application.port.out.GetAddressCodePort;
+import org.sopt.carena.institution.application.port.out.GetInstitutionInfoPort;
+import org.sopt.carena.institution.domain.vo.InstitutionInfoList;
+import org.sopt.carena.institution.domain.vo.SidoCode;
+import org.sopt.carena.institution.domain.vo.SigunguCode;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PublicDataAdapter implements GetAddressCodePort {
+	private final PublicDataClient publicDataClient;
+
+	public List<SidoCode> getSidoCodeList() {
+		return AddressCodeMapper.toSidoCodes(publicDataClient.getSidoCode());
+	}
+
+	public List<SigunguCode> getSigunguAddressCodeBySidoCode(final int sidoCode) {
+		return AddressCodeMapper.toSigunguCodes(publicDataClient.getSigunguCode(sidoCode));
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/PublicDataAdapter.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/PublicDataAdapter.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class PublicDataAdapter implements GetAddressCodePort {
+public class PublicDataAdapter implements GetAddressCodePort, GetInstitutionInfoPort {
 	private final PublicDataClient publicDataClient;
 
 	public List<SidoCode> getSidoCodeList() {
@@ -25,5 +25,16 @@ public class PublicDataAdapter implements GetAddressCodePort {
 
 	public List<SigunguCode> getSigunguAddressCodeBySidoCode(final int sidoCode) {
 		return AddressCodeMapper.toSigunguCodes(publicDataClient.getSigunguCode(sidoCode));
+	}
+
+	public InstitutionInfoList searchInstitutionInfo(
+			final int page,
+			final Integer sidoCode,
+			final Integer sigunguCode,
+			final int type,
+			final String institutionName
+	) {
+		return InstitutionInfoMapper.toInstitutionInfoList(
+				publicDataClient.getInstitutionInfo(page, sidoCode, sigunguCode, type, institutionName));
 	}
 }

--- a/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/mapper/AddressCodeMapper.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/mapper/AddressCodeMapper.java
@@ -1,0 +1,32 @@
+package org.sopt.carena.institution.adapter.out.web.publicdata.mapper;
+
+import java.util.List;
+
+import org.sopt.carena.infrastructure.publicdata.dto.SidoCodeResponse;
+import org.sopt.carena.infrastructure.publicdata.dto.SigunguCodeResponse;
+import org.sopt.carena.institution.domain.vo.SidoCode;
+import org.sopt.carena.institution.domain.vo.SigunguCode;
+import org.sopt.carena.institution.exception.AddressCodeNotExistsException;
+import org.sopt.carena.institution.exception.PublicDataAccessFailException;
+
+public class AddressCodeMapper {
+	public static List<SidoCode> toSidoCodes(SidoCodeResponse response) {
+		try{
+			return response.body().items().item().stream()
+					.map(item -> new SidoCode(item.siDoNm(), item.siDoCd()))
+					.toList();
+		} catch (NullPointerException e){
+			throw new PublicDataAccessFailException();
+		}
+	}
+
+	public static List<SigunguCode> toSigunguCodes(SigunguCodeResponse response) {
+		try {
+			return response.body().items().item().stream()
+					.map(item -> new SigunguCode(item.siGunGuNm(), item.siDoCd(), item.siGunGuCd()))
+					.toList();
+		} catch (NullPointerException e) {
+			throw new AddressCodeNotExistsException();
+		}
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/mapper/InstitutionInfoMapper.java
+++ b/src/main/java/org/sopt/carena/institution/adapter/out/web/publicdata/mapper/InstitutionInfoMapper.java
@@ -1,0 +1,47 @@
+package org.sopt.carena.institution.adapter.out.web.publicdata.mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sopt.carena.infrastructure.publicdata.dto.InstitutionInfoResponse;
+import org.sopt.carena.institution.domain.vo.CheckupType;
+import org.sopt.carena.institution.domain.vo.InstitutionInfo;
+import org.sopt.carena.institution.domain.vo.InstitutionInfoList;
+
+public class InstitutionInfoMapper {
+	public static InstitutionInfoList toInstitutionInfoList(InstitutionInfoResponse response) {
+		try{
+			List<InstitutionInfo> institutions = response.body().items().item().stream()
+					.map(item -> new InstitutionInfo(item.hmcNm(), item.locAddr(), item.cyVl(), item.cxVl(),
+							resolveCheckupTypes(item)))
+					.toList();
+
+			return InstitutionInfoList.of(institutions,
+					response.body().pageNo(),
+					response.body().numOfRows(),
+					response.body().totalCount());
+		} catch (NullPointerException e) {
+			return InstitutionInfoList.of(List.of(), 0, 0, 0);
+		}
+	}
+
+	private static List<String> resolveCheckupTypes(InstitutionInfoResponse.Item item) {
+		List<String> types = new ArrayList<>();
+
+		if (item.grenChrgTypeCd() == 1)
+			types.add(CheckupType.GENERAL.getName());
+		if (item.mchkChrgTypeCd() == 1)
+			types.add(CheckupType.ORAL.getName());
+		if (item.ichkChrgTypeCd() == 1)
+			types.add(CheckupType.INFANT.getName());
+		if (item.bcExmdChrgTypeCd() == 1
+				|| item.ccExmdChrgTypeCd() == 1
+				|| item.cvxcaExmdChrgTypeCd() == 1
+				|| item.lvcaExmdChrgTypeCd() == 1
+				|| item.stmcaExmdChrgTypeCd() == 1) {
+			types.add(CheckupType.CANCER.getName());
+		}
+
+		return types;
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/application/dto/view/InstitutionListView.java
+++ b/src/main/java/org/sopt/carena/institution/application/dto/view/InstitutionListView.java
@@ -1,0 +1,26 @@
+package org.sopt.carena.institution.application.dto.view;
+
+import java.util.List;
+
+import org.sopt.carena.institution.domain.vo.InstitutionInfo;
+import org.sopt.carena.institution.domain.vo.InstitutionInfoList;
+
+public record InstitutionListView(
+		List<InstitutionInfo> result,
+		int currentPage,
+		int totalPage,
+		int totalCount
+) {
+	public static InstitutionListView from(final InstitutionInfoList institutionInfoList) {
+		int totalCount = institutionInfoList.metadata().totalCount();
+		int pageSize = institutionInfoList.metadata().pageSize();
+		int totalPage = (int) Math.ceil((double) totalCount / pageSize);
+
+		return new InstitutionListView(
+				institutionInfoList.institutions(),
+				institutionInfoList.metadata().currentPage(),
+				totalPage,
+				totalCount
+		);
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/application/dto/view/SidoCodeView.java
+++ b/src/main/java/org/sopt/carena/institution/application/dto/view/SidoCodeView.java
@@ -1,0 +1,24 @@
+package org.sopt.carena.institution.application.dto.view;
+
+import java.util.List;
+
+import org.sopt.carena.institution.domain.vo.SidoCode;
+
+public record SidoCodeView(
+		List<SidoCodeInfo> result
+) {
+	public static SidoCodeView from(List<SidoCode> sidoCodes) {
+		return new SidoCodeView(sidoCodes.stream()
+				.map(SidoCodeInfo::from)
+				.toList());
+	}
+
+	private record SidoCodeInfo(
+			String sidoName,
+			int sidoCode
+	) {
+		private static SidoCodeInfo from(SidoCode sidoCode) {
+			return new SidoCodeInfo(sidoCode.sidoName(), sidoCode.sidoCode());
+		}
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/application/dto/view/SigunguCodeView.java
+++ b/src/main/java/org/sopt/carena/institution/application/dto/view/SigunguCodeView.java
@@ -1,0 +1,25 @@
+package org.sopt.carena.institution.application.dto.view;
+
+import java.util.List;
+
+import org.sopt.carena.institution.domain.vo.SigunguCode;
+
+public record SigunguCodeView(
+		List<SigunguCodeInfo> result
+) {
+	public static SigunguCodeView from(List<SigunguCode> sigunguCodes) {
+		return new SigunguCodeView(sigunguCodes.stream()
+				.map(SigunguCodeInfo::from)
+				.toList());
+	}
+
+	private record SigunguCodeInfo(
+			String sidoName,
+			int sidoCode,
+			int sigunguCode
+	) {
+		private static SigunguCodeInfo from(SigunguCode sigunguCode) {
+			return new SigunguCodeInfo(sigunguCode.sigunguName(), sigunguCode.sidoCode(), sigunguCode.sigunguCode());
+		}
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/application/dto/view/SigunguCodeView.java
+++ b/src/main/java/org/sopt/carena/institution/application/dto/view/SigunguCodeView.java
@@ -14,7 +14,7 @@ public record SigunguCodeView(
 	}
 
 	private record SigunguCodeInfo(
-			String sidoName,
+			String sigunguName,
 			int sidoCode,
 			int sigunguCode
 	) {

--- a/src/main/java/org/sopt/carena/institution/application/port/in/GetAddressCodeUseCase.java
+++ b/src/main/java/org/sopt/carena/institution/application/port/in/GetAddressCodeUseCase.java
@@ -1,0 +1,10 @@
+package org.sopt.carena.institution.application.port.in;
+
+import org.sopt.carena.institution.application.dto.view.SidoCodeView;
+import org.sopt.carena.institution.application.dto.view.SigunguCodeView;
+
+public interface GetAddressCodeUseCase {
+	SidoCodeView getSidoCodes();
+
+	SigunguCodeView getSigunguCodes(int sidoCode);
+}

--- a/src/main/java/org/sopt/carena/institution/application/port/in/GetInstitutionInfoUseCase.java
+++ b/src/main/java/org/sopt/carena/institution/application/port/in/GetInstitutionInfoUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.institution.application.port.in;
+
+import org.sopt.carena.institution.application.dto.view.InstitutionListView;
+
+public interface GetInstitutionInfoUseCase {
+	InstitutionListView searchInstitution(int page, Integer sidoCode, Integer sigunguCode, int type, String institutionName);
+}

--- a/src/main/java/org/sopt/carena/institution/application/port/out/GetAddressCodePort.java
+++ b/src/main/java/org/sopt/carena/institution/application/port/out/GetAddressCodePort.java
@@ -1,0 +1,12 @@
+package org.sopt.carena.institution.application.port.out;
+
+import java.util.List;
+
+import org.sopt.carena.institution.domain.vo.SidoCode;
+import org.sopt.carena.institution.domain.vo.SigunguCode;
+
+public interface GetAddressCodePort {
+	List<SidoCode> getSidoCodeList();
+
+	List<SigunguCode> getSigunguAddressCodeBySidoCode(int sidoCode);
+}

--- a/src/main/java/org/sopt/carena/institution/application/port/out/GetInstitutionInfoPort.java
+++ b/src/main/java/org/sopt/carena/institution/application/port/out/GetInstitutionInfoPort.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.institution.application.port.out;
+
+import org.sopt.carena.institution.domain.vo.InstitutionInfoList;
+
+public interface GetInstitutionInfoPort {
+	InstitutionInfoList searchInstitutionInfo(int page, Integer sidoCode, Integer sigunguCode, int type, String institutionName);
+}

--- a/src/main/java/org/sopt/carena/institution/application/service/GetAddressCodeService.java
+++ b/src/main/java/org/sopt/carena/institution/application/service/GetAddressCodeService.java
@@ -1,0 +1,23 @@
+package org.sopt.carena.institution.application.service;
+
+import org.sopt.carena.institution.application.dto.view.SidoCodeView;
+import org.sopt.carena.institution.application.dto.view.SigunguCodeView;
+import org.sopt.carena.institution.application.port.in.GetAddressCodeUseCase;
+import org.sopt.carena.institution.application.port.out.GetAddressCodePort;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetAddressCodeService implements GetAddressCodeUseCase {
+	private final GetAddressCodePort getAddressCodePort;
+
+	public SidoCodeView getSidoCodes() {
+		return SidoCodeView.from(getAddressCodePort.getSidoCodeList());
+	}
+
+	public SigunguCodeView getSigunguCodes(final int sidoCode) {
+		return SigunguCodeView.from(getAddressCodePort.getSigunguAddressCodeBySidoCode(sidoCode));
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/application/service/GetInstitutionInfoService.java
+++ b/src/main/java/org/sopt/carena/institution/application/service/GetInstitutionInfoService.java
@@ -1,0 +1,25 @@
+package org.sopt.carena.institution.application.service;
+
+import org.sopt.carena.institution.application.dto.view.InstitutionListView;
+import org.sopt.carena.institution.application.port.in.GetInstitutionInfoUseCase;
+import org.sopt.carena.institution.application.port.out.GetInstitutionInfoPort;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetInstitutionInfoService implements GetInstitutionInfoUseCase {
+	private final GetInstitutionInfoPort getInstitutionInfoPort;
+
+	public InstitutionListView searchInstitution(
+			final int page,
+			final Integer sidoCode,
+			final Integer sigunguCode,
+			final int type,
+			final String institutionName
+	) {
+		return InstitutionListView.from(
+				getInstitutionInfoPort.searchInstitutionInfo(page, sidoCode, sigunguCode, type, institutionName));
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/domain/vo/CheckupType.java
+++ b/src/main/java/org/sopt/carena/institution/domain/vo/CheckupType.java
@@ -1,0 +1,16 @@
+package org.sopt.carena.institution.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CheckupType {
+	GENERAL("일반검진", 1),
+	ORAL("구강검진", 2),
+	CANCER("암검진", 3),
+	INFANT("영유아검진", 6);
+
+	private final String name;
+	private final int code;
+}

--- a/src/main/java/org/sopt/carena/institution/domain/vo/InstitutionInfo.java
+++ b/src/main/java/org/sopt/carena/institution/domain/vo/InstitutionInfo.java
@@ -1,0 +1,11 @@
+package org.sopt.carena.institution.domain.vo;
+
+import java.util.List;
+
+public record InstitutionInfo(
+		String institutionName,
+		String institutionAddress,
+		double latitude,
+		double longitude,
+		List<String> types
+) {}

--- a/src/main/java/org/sopt/carena/institution/domain/vo/InstitutionInfoList.java
+++ b/src/main/java/org/sopt/carena/institution/domain/vo/InstitutionInfoList.java
@@ -1,0 +1,25 @@
+package org.sopt.carena.institution.domain.vo;
+
+import java.util.List;
+
+public record InstitutionInfoList(
+		List<InstitutionInfo> institutions,
+		Metadata metadata
+) {
+	public static InstitutionInfoList of(
+			final List<InstitutionInfo> institutions,
+			final int currentPage,
+			final int pageSize,
+			final int totalCount
+	) {
+		return new InstitutionInfoList(
+				institutions, new Metadata(currentPage, pageSize, totalCount)
+		);
+	}
+
+	public record Metadata(
+			int currentPage,
+			int pageSize,
+			int totalCount
+	) {}
+}

--- a/src/main/java/org/sopt/carena/institution/domain/vo/SidoCode.java
+++ b/src/main/java/org/sopt/carena/institution/domain/vo/SidoCode.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.institution.domain.vo;
+
+public record SidoCode(
+		String sidoName,
+		int sidoCode
+) {
+}

--- a/src/main/java/org/sopt/carena/institution/domain/vo/SigunguCode.java
+++ b/src/main/java/org/sopt/carena/institution/domain/vo/SigunguCode.java
@@ -1,0 +1,8 @@
+package org.sopt.carena.institution.domain.vo;
+
+public record SigunguCode(
+		String sigunguName,
+		int sidoCode,
+		int sigunguCode
+) {
+}

--- a/src/main/java/org/sopt/carena/institution/exception/AddressCodeNotExistsException.java
+++ b/src/main/java/org/sopt/carena/institution/exception/AddressCodeNotExistsException.java
@@ -1,0 +1,10 @@
+package org.sopt.carena.institution.exception;
+
+import org.sopt.carena.global.exception.BaseException;
+import org.sopt.carena.institution.exception.code.ErrorCode;
+
+public class AddressCodeNotExistsException extends BaseException {
+	public AddressCodeNotExistsException() {
+		super(ErrorCode.SIDO_CODE_NOT_EXISTS);
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/exception/PublicDataAccessFailException.java
+++ b/src/main/java/org/sopt/carena/institution/exception/PublicDataAccessFailException.java
@@ -1,0 +1,10 @@
+package org.sopt.carena.institution.exception;
+
+import org.sopt.carena.global.exception.BaseException;
+import org.sopt.carena.institution.exception.code.ErrorCode;
+
+public class PublicDataAccessFailException extends BaseException {
+	public PublicDataAccessFailException() {
+		super(ErrorCode.PUBLIC_DATA_ACCESS_FAIL);
+	}
+}

--- a/src/main/java/org/sopt/carena/institution/exception/code/ErrorCode.java
+++ b/src/main/java/org/sopt/carena/institution/exception/code/ErrorCode.java
@@ -1,0 +1,17 @@
+package org.sopt.carena.institution.exception.code;
+
+import org.sopt.carena.global.api.code.ErrorResultCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode implements ErrorResultCode {
+	PUBLIC_DATA_ACCESS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "공공데이터 로딩에 실패했습니다."),
+	SIDO_CODE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 시/도 코드입니다.");
+
+	private final HttpStatus status;
+	private final String message;
+}


### PR DESCRIPTION
## **🚀 Related issue**

closes #49 

## **#️⃣ Summary**

- 공공데이터포털의 API를 이용하여 건강검진 기관 조회 기능을 구현합니다.
- 건강검진 기관 조회를 위한 시/도 단위 주소 코드와 시/군/구 단위 주소 코드의 조회 기능을 구현합니다.

## **🎯 Work Description**

- [x] 검색을 위한 시도, 시군구 코드 조회 기능 구현
- [x] 검진 유형 및 지역 기반 검진 기관 조회 기능 구현

## **👍 동작 확인**

- 시/도 단위 주소 코드 조회
  <img width="975" height="738" alt="스크린샷 2026-03-05 오후 11 29 54" src="https://github.com/user-attachments/assets/22159225-be25-49f1-b35e-b227b7421527" />

- 시/군/구 단위 주소 코드 조회
  <img width="979" height="756" alt="스크린샷 2026-03-05 오후 11 29 37" src="https://github.com/user-attachments/assets/962d1a70-5fbf-4f78-a751-0d0fbd2faa6a" />

- 건강 검진기관 조회
  <img width="971" height="757" alt="스크린샷 2026-03-05 오후 11 29 22" src="https://github.com/user-attachments/assets/deea9050-caef-4872-945a-d4d4dd15dda8" />

## **💬 To Reviewers**

- 주소 코드 조회에서는 반환값이 최대 50개 이하라 페이지를 나누지 않고 한번에 반환하도록 구현했습니다.
- 현재 구현한 3개의 API 모두 외부 API 요청을 이용하므로 추후 재시도 로직을 추가해야할 것 같습니다.
- xml을 역직렬화 하는 과정에서 외부 API의 요청을 받아오는 DTO가 조금 지저분해 보이긴 하는데 혹시 깔끔하게 만드는 방법 아시면 추천좀...ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 시도/시군구 주소 코드 조회 API 추가
  * 검진 기관 정보 검색 API 추가 — 페이지네이션, 지역·유형·이름 필터링 지원

* **Bug Fixes**
  * 요청 파라미터 누락 시 명확한 에러 응답 추가

* **Chores**
  * 외부 공공데이터 XML 응답 지원 및 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->