### PR TITLE
feat: 건강 검진 결과 수정 기능 구현

### DIFF
--- a/src/main/java/org/sopt/carena/global/common/BaseEntity.java
+++ b/src/main/java/org/sopt/carena/global/common/BaseEntity.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -14,5 +15,6 @@ import lombok.Getter;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 	@CreatedDate
+	@Column(updatable = false)
 	private LocalDateTime createdAt;
 }

--- a/src/main/java/org/sopt/carena/healthreport/adapter/in/web/code/SuccessCode.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/in/web/code/SuccessCode.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessCode implements SuccessResultCode {
 	EXTRACT_TEXT_SUCCESS(HttpStatus.OK, "텍스트 추출이 완료되었습니다."),
 	HEALTH_REPORT_CREATED(HttpStatus.CREATED, "건강 검진 기록이 생성되었습니다."),
+	HEALTH_REPORT_UPDATED(HttpStatus.OK, "건강 검진 기록 수정이 완료되었습니다."),
 	HEALTH_REPORT_FOUND(HttpStatus.OK, "건강 검진 기록 조회가 완료되었습니다.");
 
 	private final HttpStatus status;

--- a/src/main/java/org/sopt/carena/healthreport/adapter/in/web/controller/HealthReportApiDocs.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/in/web/controller/HealthReportApiDocs.java
@@ -3,7 +3,7 @@ package org.sopt.carena.healthreport.adapter.in.web.controller;
 import java.time.LocalDate;
 
 import org.sopt.carena.global.api.response.SuccessResponse;
-import org.sopt.carena.healthreport.adapter.in.web.request.CreateHealthReportRequest;
+import org.sopt.carena.healthreport.adapter.in.web.request.WriteHealthReportRequest;
 import org.sopt.carena.healthreport.application.dto.view.EntireHealthReportView;
 import org.sopt.carena.healthreport.application.dto.view.ExtractedTextView;
 import org.sopt.carena.healthreport.application.dto.view.HealthReportDateListView;
@@ -22,7 +22,10 @@ public interface HealthReportApiDocs {
 	ResponseEntity<SuccessResponse<ExtractedTextView>> extractText(MultipartFile file);
 
 	@Operation(summary = "건강 검진 결과 저장", description = "건강 검진 결과를 저장합니다.")
-	ResponseEntity<SuccessResponse<Void>> createHealthReport(long memberId, @Valid CreateHealthReportRequest request);
+	ResponseEntity<SuccessResponse<Void>> createHealthReport(long memberId, @Valid WriteHealthReportRequest request);
+
+	@Operation(summary = "건강 검진 결과 수정", description = "건강 검진 결과를 수정합니다.")
+	ResponseEntity<SuccessResponse<Void>> updateHealthReport(long memberId, String healthReportId, @Valid WriteHealthReportRequest request);
 
 	@Operation(summary = "저장된 건강 검진 결과 데이터의 날짜 목록 조회", description = "건강 검진 결과 데이터의 날짜 목록을 조회합니다.")
 	ResponseEntity<SuccessResponse<HealthReportDateListView>> getReportDateList(long id, @Min(1) int index);

--- a/src/main/java/org/sopt/carena/healthreport/adapter/in/web/controller/HealthReportController.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/in/web/controller/HealthReportController.java
@@ -4,15 +4,17 @@ import java.time.LocalDate;
 
 import org.sopt.carena.global.api.response.ApiResponse;
 import org.sopt.carena.global.api.response.SuccessResponse;
-import org.sopt.carena.healthreport.adapter.in.web.request.CreateHealthReportRequest;
+import org.sopt.carena.healthreport.adapter.in.web.request.WriteHealthReportRequest;
 import org.sopt.carena.healthreport.adapter.in.web.code.SuccessCode;
 import org.sopt.carena.healthreport.application.dto.command.CreateHealthReportCommand;
+import org.sopt.carena.healthreport.application.dto.command.UpdateHealthReportCommand;
 import org.sopt.carena.healthreport.application.dto.command.ExtractTextCommand;
 import org.sopt.carena.healthreport.application.dto.view.EntireHealthReportView;
 import org.sopt.carena.healthreport.application.dto.view.ExtractedTextView;
 import org.sopt.carena.healthreport.application.dto.view.HealthReportDateListView;
 import org.sopt.carena.healthreport.application.dto.view.HealthReportHistoryView;
 import org.sopt.carena.healthreport.application.port.in.CreateHealthReportUseCase;
+import org.sopt.carena.healthreport.application.port.in.UpdateHealthReportUseCase;
 import org.sopt.carena.healthreport.application.port.in.ExtractTextFromImageUseCase;
 import org.sopt.carena.healthreport.application.port.in.GetEntireHealthReportUseCase;
 import org.sopt.carena.healthreport.application.port.in.GetReportDateListUseCase;
@@ -22,6 +24,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -38,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 public class HealthReportController implements HealthReportApiDocs {
 	private final ExtractTextFromImageUseCase extractTextFromImageUseCase;
 	private final CreateHealthReportUseCase createHealthReportUseCase;
+	private final UpdateHealthReportUseCase updateHealthReportUseCase;
 	private final GetReportDateListUseCase getReportDateListUseCase;
 	private final GetEntireHealthReportUseCase getEntireHealthReportUseCase;
 	private final HealthReportItemHistoryUseCase healthReportItemHistoryUseCase;
@@ -54,12 +58,24 @@ public class HealthReportController implements HealthReportApiDocs {
 	@PostMapping
 	public ResponseEntity<SuccessResponse<Void>> createHealthReport(
 			@AuthenticationPrincipal final long memberId,
-			@Valid @RequestBody final CreateHealthReportRequest request
+			@Valid @RequestBody final WriteHealthReportRequest request
 	) {
 		createHealthReportUseCase.createHealthReport(CreateHealthReportCommand.of(memberId, request));
 
 		return ResponseEntity.status(SuccessCode.HEALTH_REPORT_CREATED.getStatus())
 				.body(ApiResponse.success(SuccessCode.HEALTH_REPORT_CREATED));
+	}
+
+	@PutMapping(path = "/{healthReportId}")
+	public ResponseEntity<SuccessResponse<Void>> updateHealthReport(
+			@AuthenticationPrincipal final long memberId,
+			@PathVariable(name = "healthReportId") final String healthReportId,
+			@Valid @RequestBody final WriteHealthReportRequest request
+	) {
+		updateHealthReportUseCase.updateHealthReport(UpdateHealthReportCommand.of(memberId, Long.parseLong(healthReportId), request));
+
+		return ResponseEntity.status(SuccessCode.HEALTH_REPORT_UPDATED.getStatus())
+				.body(ApiResponse.success(SuccessCode.HEALTH_REPORT_UPDATED));
 	}
 
 	@GetMapping(path = "/dates")

--- a/src/main/java/org/sopt/carena/healthreport/adapter/in/web/request/WriteHealthReportRequest.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/in/web/request/WriteHealthReportRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record CreateHealthReportRequest(
+public record WriteHealthReportRequest(
 		@NotNull
 		LocalDate healthCheckDate,
 		@NotBlank

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportEmbeddingPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportEmbeddingPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package org.sopt.carena.healthreport.adapter.out.persistence;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.sopt.carena.healthreport.adapter.out.persistence.entity.HealthReportEmbeddingEntity;
 import org.sopt.carena.healthreport.adapter.out.persistence.entity.HealthReportEntity;
 import org.sopt.carena.healthreport.adapter.out.persistence.mapper.HealthReportEmbeddingMapper;
@@ -31,10 +32,17 @@ public class HealthReportEmbeddingPersistenceAdapter implements HealthReportEmbe
 	@Transactional
 	public void saveHealthReportEmbedding(HealthReportEmbedding healthReportEmbedding) {
 		MemberEntity memberEntityProxy = memberJpaRepository.getReferenceById(healthReportEmbedding.getMemberId());
-		HealthReportEntity healthReportEntityProxy = healthReportRepository.getReferenceById(healthReportEmbedding.getHealthReportId());
+		HealthReportEntity healthReportEntityProxy = healthReportRepository.getReferenceById(
+				healthReportEmbedding.getHealthReportId());
 
-		HealthReportEmbeddingEntity healthReportEmbeddingEntity = HealthReportEmbeddingMapper
-				.toEntity(healthReportEmbedding, memberEntityProxy, healthReportEntityProxy);
+		Long existingEmbeddingId = healthReportEmbeddingRepository.findByHealthReportId(
+						healthReportEmbedding.getHealthReportId())
+				.map(HealthReportEmbeddingEntity::getId)
+				.orElse(null);
+
+		HealthReportEmbeddingEntity healthReportEmbeddingEntity = (existingEmbeddingId == null) ?
+				HealthReportEmbeddingMapper.toEntity(healthReportEmbedding, memberEntityProxy, healthReportEntityProxy) :
+				HealthReportEmbeddingMapper.toEntity(existingEmbeddingId, healthReportEmbedding, memberEntityProxy, healthReportEntityProxy);
 
 		healthReportEmbeddingRepository.save(healthReportEmbeddingEntity);
 	}

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/entity/HealthReportEmbeddingEntity.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/entity/HealthReportEmbeddingEntity.java
@@ -52,11 +52,13 @@ public class HealthReportEmbeddingEntity extends BaseEntity {
 
 	@Builder
 	private HealthReportEmbeddingEntity(
+			Long id,
 			String embeddingText,
 			float[] embedding,
 			HealthReportEntity healthReportEntity,
 			MemberEntity memberEntity
 	) {
+		this.id = id;
 		this.embeddingText = embeddingText;
 		this.embedding = embedding;
 		this.healthReportEntity = healthReportEntity;

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/entity/HealthReportEntity.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/entity/HealthReportEntity.java
@@ -102,6 +102,7 @@ public class HealthReportEntity extends BaseEntity {
 
 	@Builder
 	private HealthReportEntity(
+			final Long id,
 			final LocalDate healthCheckDate,
 			final String institutionName,
 			final Double height,
@@ -124,6 +125,7 @@ public class HealthReportEntity extends BaseEntity {
 			final MemberEntity memberEntity,
 			final Gender gender
 	) {
+		this.id = id;
 		this.healthCheckDate = healthCheckDate;
 		this.institutionName = institutionName;
 		this.height = height;

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/mapper/HealthReportEmbeddingMapper.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/mapper/HealthReportEmbeddingMapper.java
@@ -22,11 +22,26 @@ public class HealthReportEmbeddingMapper {
 			final HealthReportEntity healthReportEntity
 	) {
 		return HealthReportEmbeddingEntity.builder()
+				.id(domain.getId())
 				.embeddingText(domain.getEmbeddingText())
 				.embedding(domain.getEmbedding())
 				.memberEntity(memberEntity)
 				.healthReportEntity(healthReportEntity)
 				.build();
+	}
 
+	public static HealthReportEmbeddingEntity toEntity(
+			final Long id,
+			final HealthReportEmbedding domain,
+			final MemberEntity memberEntity,
+			final HealthReportEntity healthReportEntity
+	) {
+		return HealthReportEmbeddingEntity.builder()
+				.id(id)
+				.embeddingText(domain.getEmbeddingText())
+				.embedding(domain.getEmbedding())
+				.memberEntity(memberEntity)
+				.healthReportEntity(healthReportEntity)
+				.build();
 	}
 }

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/mapper/HealthReportMapper.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/mapper/HealthReportMapper.java
@@ -35,6 +35,7 @@ public class HealthReportMapper {
 
 	public static HealthReportEntity toEntity(final HealthReport domain) {
 		return HealthReportEntity.builder()
+				.id(domain.getId())
 				.gender(domain.getGender())
 				.healthCheckDate(domain.getHealthCheckDate())
 				.institutionName(domain.getInstitutionName())
@@ -60,6 +61,7 @@ public class HealthReportMapper {
 
 	public static HealthReportEntity toEntity(final HealthReport domain, final MemberEntity memberEntity) {
 		return HealthReportEntity.builder()
+				.id(domain.getId())
 				.gender(domain.getGender())
 				.healthCheckDate(domain.getHealthCheckDate())
 				.institutionName(domain.getInstitutionName())

--- a/src/main/java/org/sopt/carena/healthreport/application/dto/command/UpdateHealthReportCommand.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/dto/command/UpdateHealthReportCommand.java
@@ -4,8 +4,9 @@ import java.time.LocalDate;
 
 import org.sopt.carena.healthreport.adapter.in.web.request.WriteHealthReportRequest;
 
-public record CreateHealthReportCommand(
+public record UpdateHealthReportCommand(
 		long memberId,
+		long healthReportId,
 		LocalDate healthCheckDate,
 		String institutionName,
 		Double height,
@@ -26,9 +27,10 @@ public record CreateHealthReportCommand(
 		Double alt,
 		Double gammaGtp
 ) {
-	public static CreateHealthReportCommand of(final long memberId, final WriteHealthReportRequest request) {
-		return new CreateHealthReportCommand(
+	public static UpdateHealthReportCommand of(final long memberId, final long healthReportId, final WriteHealthReportRequest request) {
+		return new UpdateHealthReportCommand(
 				memberId,
+				healthReportId,
 				request.healthCheckDate(),
 				request.institutionName(),
 				request.height(),

--- a/src/main/java/org/sopt/carena/healthreport/application/port/in/SaveHealthReportEmbeddingUseCase.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/in/SaveHealthReportEmbeddingUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.carena.healthreport.application.port.in;
+
+import org.sopt.carena.healthreport.domain.HealthReport;
+import org.sopt.carena.member.domain.Member;
+
+public interface SaveHealthReportEmbeddingUseCase {
+	void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport);
+}

--- a/src/main/java/org/sopt/carena/healthreport/application/port/in/UpdateHealthReportUseCase.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/in/UpdateHealthReportUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.carena.healthreport.application.port.in;
+
+import org.sopt.carena.healthreport.application.dto.command.UpdateHealthReportCommand;
+
+public interface UpdateHealthReportUseCase {
+	void updateHealthReport(UpdateHealthReportCommand command);
+}

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -2,15 +2,12 @@ package org.sopt.carena.healthreport.application.service;
 
 import java.util.concurrent.ExecutorService;
 
-import org.sopt.carena.diet.application.port.out.EmbeddingPort;
-import org.sopt.carena.diet.exception.embedding.EmbeddingFailedException;
 import org.sopt.carena.healthreport.application.converter.HealthReportEmbeddingConverter;
 import org.sopt.carena.healthreport.application.dto.command.CreateHealthReportCommand;
 import org.sopt.carena.healthreport.application.port.in.CreateHealthReportUseCase;
-import org.sopt.carena.healthreport.application.port.out.HealthReportEmbeddingPersistencePort;
+import org.sopt.carena.healthreport.application.port.in.SaveHealthReportEmbeddingUseCase;
 import org.sopt.carena.healthreport.application.port.out.HealthReportPersistencePort;
 import org.sopt.carena.healthreport.domain.HealthReport;
-import org.sopt.carena.healthreport.domain.HealthReportEmbedding;
 import org.sopt.carena.healthreport.exception.healthreport.HealthReportAlreadyExistsException;
 import org.sopt.carena.member.application.port.in.HealthScoreUseCase;
 import org.sopt.carena.member.application.port.out.MemberPersistencePort;
@@ -18,9 +15,6 @@ import org.sopt.carena.member.domain.Member;
 
 import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
 import org.sopt.carena.recommend.application.port.in.CreateRecommendedMealUseCase;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -33,63 +27,31 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 	private final CreateRecommendedMealUseCase createRecommendedMealUseCase;
 	private final HealthReportPersistencePort healthReportPersistencePort;
 	private final MemberPersistencePort memberPersistencePort;
-	private final HealthReportEmbeddingPersistencePort healthReportEmbeddingPersistencePort;
-	private final EmbeddingPort embeddingPort;
-	private final ExecutorService virtualExecutorService;
 	private final HealthScoreUseCase healthScoreUseCase;
+	private final SaveHealthReportEmbeddingUseCase saveHealthReportEmbeddingUseCase;
+	private final ExecutorService virtualExecutorService;
 
-	public void createHealthReport(final CreateHealthReportCommand commend) {
-		Member member = memberPersistencePort.getMemberById(commend.memberId())
+	public void createHealthReport(final CreateHealthReportCommand command) {
+		Member member = memberPersistencePort.getMemberById(command.memberId())
 				.orElseThrow(MemberNotFoundException::new);
 
 		if (healthReportPersistencePort.existsByMemberIdAndHealthCheckDate(
-				commend.memberId(),
-				commend.healthCheckDate()
+				command.memberId(),
+				command.healthCheckDate()
 		)) {
 			throw new HealthReportAlreadyExistsException();
 		}
 
 		HealthReport healthReport = healthReportPersistencePort
-				.saveHealthReport(HealthReport.create(commend, member.getGender()));
+				.saveHealthReport(HealthReport.create(command, member.getGender()));
 
-        String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);
+		String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);
 
 		//점수 계산 -> 여기선 멤버의  Usecase호출 / member에서 점수 계산~~~
 		healthScoreUseCase.updateMemberScore(member, healthReport);
 
-        virtualExecutorService.submit(() -> embeddingAndSave(embeddingText, member, healthReport));
+		virtualExecutorService.submit(
+				() -> saveHealthReportEmbeddingUseCase.embeddingAndSave(embeddingText, member, healthReport));
 		createRecommendedMealUseCase.saveRagResult(member.getId());
-	}
-
-	@Retryable(
-			retryFor = EmbeddingFailedException.class,
-			maxAttempts = 3,
-			backoff = @Backoff(delay = 5000, multiplier = 2),
-			recover = "recoverEmbedding"
-	)
-    public void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport) {
-        // 임베딩 호출
-        float[] embedding = embeddingPort.embed(embeddingText).vector();
-
-        // 임베딩 결과 도매인 생성
-        HealthReportEmbedding healthReportEmbedding = HealthReportEmbedding.builder()
-                .embeddingText(embeddingText)
-                .embedding(embedding)
-                .memberId(member.getId())
-                .healthReportId(healthReport.getId())
-                .build();
-
-        // 임베딩 결과 저장
-        healthReportEmbeddingPersistencePort.saveHealthReportEmbedding(healthReportEmbedding);
-    }
-
-	@Recover
-	public void recoverEmbedding(
-			final EmbeddingFailedException e,
-			final String embeddingText,
-			final Member member,
-			final HealthReport healthReport
-	){
-		log.error("임베딩 실패: {}",e.getMessage());
 	}
 }

--- a/src/main/java/org/sopt/carena/healthreport/application/service/SaveHealthReportEmbeddingService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/SaveHealthReportEmbeddingService.java
@@ -1,0 +1,58 @@
+package org.sopt.carena.healthreport.application.service;
+
+import org.sopt.carena.diet.application.port.out.EmbeddingPort;
+import org.sopt.carena.diet.exception.embedding.EmbeddingFailedException;
+import org.sopt.carena.healthreport.application.port.in.SaveHealthReportEmbeddingUseCase;
+import org.sopt.carena.healthreport.application.port.out.HealthReportEmbeddingPersistencePort;
+import org.sopt.carena.healthreport.domain.HealthReport;
+import org.sopt.carena.healthreport.domain.HealthReportEmbedding;
+import org.sopt.carena.member.domain.Member;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SaveHealthReportEmbeddingService implements SaveHealthReportEmbeddingUseCase {
+	private final EmbeddingPort embeddingPort;
+	private final HealthReportEmbeddingPersistencePort healthReportEmbeddingPersistencePort;
+
+	@Override
+	@Retryable(
+			retryFor = EmbeddingFailedException.class,
+			maxAttempts = 3,
+			backoff = @Backoff(delay = 5000, multiplier = 2),
+			recover = "recoverEmbedding"
+	)
+	public void embeddingAndSave(final String embeddingText, final Member member, final HealthReport healthReport) {
+		// 임베딩 호출
+		float[] embedding = embeddingPort.embed(embeddingText).vector();
+
+		// 임베딩 결과 도메인 생성
+		HealthReportEmbedding healthReportEmbedding = HealthReportEmbedding.builder()
+				.embeddingText(embeddingText)
+				.embedding(embedding)
+				.memberId(member.getId())
+				.healthReportId(healthReport.getId())
+				.build();
+
+		// 임베딩 결과 저장
+		healthReportEmbeddingPersistencePort.saveHealthReportEmbedding(healthReportEmbedding);
+	}
+
+	@Recover
+	public void recoverEmbedding(
+			final EmbeddingFailedException e,
+			final String embeddingText,
+			final Member member,
+			final HealthReport healthReport
+	) {
+		log.error("건강검진 리포트 임베딩 실패: memberId={}, reportId={}, error={}", 
+				member.getId(), healthReport.getId(), e.getMessage());
+	}
+}

--- a/src/main/java/org/sopt/carena/healthreport/application/service/UpdateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/UpdateHealthReportService.java
@@ -1,0 +1,65 @@
+package org.sopt.carena.healthreport.application.service;
+
+import java.util.concurrent.ExecutorService;
+
+import org.sopt.carena.healthreport.application.converter.HealthReportEmbeddingConverter;
+import org.sopt.carena.healthreport.application.dto.command.UpdateHealthReportCommand;
+import org.sopt.carena.healthreport.application.port.in.SaveHealthReportEmbeddingUseCase;
+import org.sopt.carena.healthreport.application.port.in.UpdateHealthReportUseCase;
+import org.sopt.carena.healthreport.application.port.out.HealthReportPersistencePort;
+import org.sopt.carena.healthreport.domain.HealthReport;
+import org.sopt.carena.healthreport.exception.healthreport.HealthReportAlreadyExistsException;
+import org.sopt.carena.healthreport.exception.healthreport.HealthReportNotFoundException;
+import org.sopt.carena.member.application.port.in.HealthScoreUseCase;
+import org.sopt.carena.member.application.port.out.MemberPersistencePort;
+import org.sopt.carena.member.domain.Member;
+import org.sopt.carena.member.exception.jwt.MemberNotFoundException;
+import org.sopt.carena.recommend.application.port.in.CreateRecommendedMealUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateHealthReportService implements UpdateHealthReportUseCase {
+	private final CreateRecommendedMealUseCase createRecommendedMealUseCase;
+	private final HealthReportPersistencePort healthReportPersistencePort;
+	private final MemberPersistencePort memberPersistencePort;
+	private final HealthScoreUseCase healthScoreUseCase;
+	private final SaveHealthReportEmbeddingUseCase saveHealthReportEmbeddingUseCase;
+	private final ExecutorService virtualExecutorService;
+
+	@Override
+	@Transactional
+	public void updateHealthReport(final UpdateHealthReportCommand command) {
+		Member member = memberPersistencePort.getMemberById(command.memberId())
+				.orElseThrow(MemberNotFoundException::new);
+
+		HealthReport healthReport = healthReportPersistencePort
+				.findByMemberIdAndHealthReportId(command.memberId(), command.healthReportId())
+				.orElseThrow(HealthReportNotFoundException::new);
+
+		if (!healthReport.getHealthCheckDate().equals(command.healthCheckDate())
+				&& healthReportPersistencePort.existsByMemberIdAndHealthCheckDate(
+				command.memberId(),
+				command.healthCheckDate()
+		)) {
+			throw new HealthReportAlreadyExistsException();
+		}
+
+		healthReport.update(command);
+		healthReportPersistencePort.saveHealthReport(healthReport);
+
+		String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);
+
+		// Update score
+		healthScoreUseCase.updateMemberScore(member, healthReport);
+
+		virtualExecutorService.submit(
+				() -> saveHealthReportEmbeddingUseCase.embeddingAndSave(embeddingText, member, healthReport));
+		createRecommendedMealUseCase.saveRagResult(member.getId());
+	}
+}

--- a/src/main/java/org/sopt/carena/healthreport/domain/HealthReport.java
+++ b/src/main/java/org/sopt/carena/healthreport/domain/HealthReport.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.sopt.carena.healthreport.application.dto.command.CreateHealthReportCommand;
+import org.sopt.carena.healthreport.application.dto.command.UpdateHealthReportCommand;
 import org.sopt.carena.healthreport.domain.status.HealthStatusCarrier;
 import org.sopt.carena.healthreport.domain.value.liver.Alt;
 import org.sopt.carena.healthreport.domain.value.liver.Ast;
@@ -28,8 +29,8 @@ import lombok.Getter;
 
 @Getter
 public class HealthReport {
-	private long id;
-	private long memberId;
+	private Long id;
+	private Long memberId;
 	private Gender gender;
 	private LocalDate healthCheckDate;
 	private String institutionName;
@@ -64,8 +65,8 @@ public class HealthReport {
 
 	@Builder
 	private HealthReport(
-			final long id,
-			final long memberId,
+			final Long id,
+			final Long memberId,
 			final Gender gender,
 			final LocalDate healthCheckDate,
 			final String institutionName,
@@ -134,6 +135,27 @@ public class HealthReport {
 				.alt(command.alt())
 				.gammaGtp(command.gammaGtp())
 				.build();
+	}
+
+	public void update(final UpdateHealthReportCommand command) {
+		this.healthCheckDate = command.healthCheckDate();
+		this.institutionName = command.institutionName();
+		this.height = Height.from(command.height());
+		this.weight = Weight.from(command.weight());
+		this.waistCircumference = WaistCircumference.of(command.waistCircumference(), gender);
+		this.bmi = Bmi.from(command.bmi());
+		this.bloodPressure = BloodPressure.of(command.systolicBloodPressure(), command.diastolicBloodPressure());
+		this.hemoglobin = Hemoglobin.of(command.hemoglobin(), gender);
+		this.fastingGlucose = FastingGlucose.from(command.fastingGlucose());
+		this.totalCholesterol = TotalCholesterol.from(command.totalCholesterol());
+		this.hdl = Hdl.from(command.hdl());
+		this.ldl = Ldl.from(command.ldl());
+		this.triglyceride = Triglyceride.from(command.triglycerides());
+		this.serumCreatinine = SerumCreatinine.from(command.serumCreatinine());
+		this.egfr = Egfr.from(command.egfr());
+		this.ast = Ast.from(command.ast());
+		this.alt = Alt.from(command.alt());
+		this.gammaGtp = GammaGtp.of(command.gammaGtp(), gender);
 	}
 
 	public List<HealthStatusCarrier> getStatusCarriers() {

--- a/src/main/java/org/sopt/carena/healthreport/domain/HealthReportEmbedding.java
+++ b/src/main/java/org/sopt/carena/healthreport/domain/HealthReportEmbedding.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class HealthReportEmbedding {
-	private long id;
+	private Long id;
 	private long memberId;
 	private long healthReportId;
 
@@ -14,7 +14,7 @@ public class HealthReportEmbedding {
 
 	@Builder
 	private HealthReportEmbedding(
-			final long id,
+			final Long id,
 			final long memberId,
 			final long healthReportId,
 			final String embeddingText,


### PR DESCRIPTION
## **🚀 Related issue**

closes #55 

## **#️⃣ Summary**

- 건강 검진 결과 데이터에 대한 수정과, 수정에 따른 임베딩 결과 수정, 추천 식단 재생성 로직을 구현합니다.

## **🎯 Work Description**

- [x] 기존 건강 검진 결과 수정 기능 구현
- [x] 기존 건강 검진 결과에 대한 임베딩 정보 수정 기능 구현
- [x] 기존 건강 검진 결과 수정에 따른 식단 추천 기능 연결

## **👍 동작 확인**

- 기존 건강 검진 결과 수정
  <img width="974" height="680" alt="스크린샷 2026-03-09 오후 4 48 54" src="https://github.com/user-attachments/assets/9bd95634-3b0c-457d-9415-4ab99dbf8df1" />


## **💬 To Reviewers**

- 검진 결과 생성에서 사용하는 `requestbody`와 형태가 동일하고 추후 변경도 동시에 적용되는 상황이라 `WriteHealthReportRequest`로 명칭을 변경하고 두 메서드에서 재사용하도록 구현하였습니다.
- 임베딩을 비롯한 비동기 로직이 재사용되어 별도의 UseCase와 Service로 분리하였습니다.
- 기존 Adapter의 생성 메서드를 재사용하여 DirtyChecking방식이 아닌 Merge방식으로 수정이 발생하도록 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기존의 건강 검진 기록을 수정할 수 있는 기능이 추가되었습니다.
  * 건강 검진 기록 수정 시 건강 점수가 자동으로 업데이트됩니다.
  * 건강 정보 변경에 따른 맞춤형 식사 권장사항이 자동으로 생성됩니다.

* **개선 사항**
  * 건강 검진 기록 관리 시스템의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->