### PR TITLE
hotfix: 검진결과 추가시 최신 여부 확인 추가

### DIFF
--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
@@ -37,6 +37,12 @@ public class HealthReportPersistenceAdapter implements HealthReportPersistencePo
 		return healthReportRepository.existsByMemberEntityIdAndHealthCheckDate(memberId, healthCheckDate);
 	}
 
+	public boolean existsNewerHealthReport(long memberId, LocalDate healthCheckDate) {
+		return healthReportRepository
+				.existsByMemberEntityIdAndHealthCheckDateAfter(memberId, healthCheckDate);
+	}
+
+
 	public Slice<HealthReport> findAllByMemberIdOrderByHealthCheckDateDesc(final long memberId, final int index) {
 		Pageable pageable = PageRequest.of(index - 1, 10);
 		return healthReportRepository.findAllByMemberEntityIdOrderByHealthCheckDateDesc(memberId, pageable)

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/HealthReportPersistenceAdapter.java
@@ -37,7 +37,7 @@ public class HealthReportPersistenceAdapter implements HealthReportPersistencePo
 		return healthReportRepository.existsByMemberEntityIdAndHealthCheckDate(memberId, healthCheckDate);
 	}
 
-	public boolean existsNewerHealthReport(long memberId, LocalDate healthCheckDate) {
+	public boolean  hasMoreRecentHealthReport(long memberId, LocalDate healthCheckDate) {
 		return healthReportRepository
 				.existsByMemberEntityIdAndHealthCheckDateAfter(memberId, healthCheckDate);
 	}

--- a/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/repository/HealthReportRepository.java
+++ b/src/main/java/org/sopt/carena/healthreport/adapter/out/persistence/repository/HealthReportRepository.java
@@ -19,6 +19,8 @@ public interface HealthReportRepository extends JpaRepository<HealthReportEntity
 
 	boolean existsByMemberEntityIdAndHealthCheckDate(Long memberId, LocalDate healthCheckDate);
 
+	boolean existsByMemberEntityIdAndHealthCheckDateAfter(long memberId, LocalDate healthCheckDate);
+
 	Slice<HealthReportEntity> findAllByMemberEntityIdOrderByHealthCheckDateDesc(long memberId, Pageable pageable);
 
 	List<HealthReportEntity> findTop5ByMemberEntityIdAndHeightIsNotNullAndHealthCheckDateLessThanEqualOrderByHealthCheckDateDesc(long memberId, LocalDate healthCheckDate);

--- a/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
@@ -12,6 +12,8 @@ public interface HealthReportPersistencePort {
 
 	boolean existsByMemberIdAndHealthCheckDate(long memberId, LocalDate healthCheckDate);
 
+	boolean existsNewerHealthReport(long memberId, LocalDate healthCheckDate);
+
 	Slice<HealthReport> findAllByMemberIdOrderByHealthCheckDateDesc(long memberId, int index);
 
 	Optional<HealthReport> findByMemberIdAndHealthReportId(long memberId, long healthReportId);

--- a/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
@@ -16,6 +16,8 @@ public interface HealthReportPersistencePort {
 
 	Optional<HealthReport> findByMemberIdAndHealthReportId(long memberId, long healthReportId);
 
+	Optional<HealthReport> findLatestHealthReportByMemberId(long memberId);
+
 	List<HealthReport> findLatestHealthReportsHeightIsNotNullByMemberId(long memberId, LocalDate healthCheckDate);
 
 	List<HealthReport> findLatestHealthReportsWeightIsNotNullByMemberId(long memberId, LocalDate healthCheckDate);

--- a/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/port/out/HealthReportPersistencePort.java
@@ -12,7 +12,7 @@ public interface HealthReportPersistencePort {
 
 	boolean existsByMemberIdAndHealthCheckDate(long memberId, LocalDate healthCheckDate);
 
-	boolean existsNewerHealthReport(long memberId, LocalDate healthCheckDate);
+	boolean  hasMoreRecentHealthReport(long memberId, LocalDate healthCheckDate);
 
 	Slice<HealthReport> findAllByMemberIdOrderByHealthCheckDateDesc(long memberId, int index);
 

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -42,13 +42,11 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 			throw new HealthReportAlreadyExistsException();
 		}
 
-		boolean isLatestReport = healthReportPersistencePort
-				.findLatestHealthReportByMemberId(command.memberId())
-				.map(latest -> !latest.getHealthCheckDate().isAfter(command.healthCheckDate()))
-				.orElse(true);
-
 		HealthReport healthReport = healthReportPersistencePort
 				.saveHealthReport(HealthReport.create(command, member.getGender()));
+
+		boolean isLatestReport = !healthReportPersistencePort
+				.existsNewerHealthReport(command.memberId(), command.healthCheckDate());
 
 		if (isLatestReport) {
 			String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -46,7 +46,7 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 				.saveHealthReport(HealthReport.create(command, member.getGender()));
 
 		boolean isLatestReport = !healthReportPersistencePort
-				.existsNewerHealthReport(command.memberId(), command.healthCheckDate());
+				.hasMoreRecentHealthReport(command.memberId(), command.healthCheckDate());
 
 		if (isLatestReport) {
 			String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);

--- a/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
+++ b/src/main/java/org/sopt/carena/healthreport/application/service/CreateHealthReportService.java
@@ -42,16 +42,21 @@ public class CreateHealthReportService implements CreateHealthReportUseCase {
 			throw new HealthReportAlreadyExistsException();
 		}
 
+		boolean isLatestReport = healthReportPersistencePort
+				.findLatestHealthReportByMemberId(command.memberId())
+				.map(latest -> !latest.getHealthCheckDate().isAfter(command.healthCheckDate()))
+				.orElse(true);
+
 		HealthReport healthReport = healthReportPersistencePort
 				.saveHealthReport(HealthReport.create(command, member.getGender()));
 
-		String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);
+		if (isLatestReport) {
+			String embeddingText = HealthReportEmbeddingConverter.toEmbeddingText(healthReport);
 
-		//점수 계산 -> 여기선 멤버의  Usecase호출 / member에서 점수 계산~~~
-		healthScoreUseCase.updateMemberScore(member, healthReport);
-
-		virtualExecutorService.submit(
-				() -> saveHealthReportEmbeddingUseCase.embeddingAndSave(embeddingText, member, healthReport));
-		createRecommendedMealUseCase.saveRagResult(member.getId());
+			healthScoreUseCase.updateMemberScore(member, healthReport);
+			virtualExecutorService.submit(
+					() -> saveHealthReportEmbeddingUseCase.embeddingAndSave(embeddingText, member, healthReport));
+			createRecommendedMealUseCase.saveRagResult(member.getId());
+		}
 	}
 }


### PR DESCRIPTION
## **🚀 Related issue**

closes #59

## **#️⃣ Summary**

- 건강검진 결과 추가시 해당 날짜보다 최신 날짜의 건강검진이 존재하는 경우 점수계산, 식단 및 임베딩 로직을 스킵하도록 설정하였습니다.

## **🎯 Work Description**

- [x] 최신 결과 아닌경우 스킵하도록 수정

## **👍 동작 확인**

- swagger나 postman 결과를 캡쳐하여 첨부
<img width="1500" height="372" alt="image" src="https://github.com/user-attachments/assets/1d560864-b3fa-4064-a0c2-09c75d690048" />
가장 최근 검진이 아닌 결과를 추가 한 경우 식단 및 점수는 가장 최신 건강검진 결과로 유지됨
<img width="2342" height="262" alt="image" src="https://github.com/user-attachments/assets/4b606cd1-5afe-4bc9-b980-6449e2eceb42" />
<img width="1696" height="322" alt="image" src="https://github.com/user-attachments/assets/137560f1-01dc-4d09-8cf8-8621b44f78c5" />

## **💬 To Reviewers**

- 리뷰어나 같이 작업하는 사람들에게 남길 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 건강 리포트 저장 시 회원별로 더 최신 리포트 존재 여부를 확인하고, 저장된 리포트가 최신일 때만 텍스트 생성·회원 점수 업데이트·추천 식단 처리를 실행합니다.
  * 회원별 최신 리포트를 조회하는 기능을 추가/개선해 최신 상태 판별과 조회가 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->