### PR TITLE
test: 건강 검진 결과 도메인 로직 테스트 작성

### DIFF
--- a/src/test/java/org/sopt/carena/healthreport/domain/HealthReportTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/HealthReportTest.java
@@ -1,0 +1,86 @@
+package org.sopt.carena.healthreport.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.carena.healthreport.application.dto.command.CreateHealthReportCommand;
+import org.sopt.carena.healthreport.application.dto.command.UpdateHealthReportCommand;
+import org.sopt.carena.healthreport.domain.status.HealthStatusCarrier;
+import org.sopt.carena.member.domain.Gender;
+
+class HealthReportTest {
+
+	@Test
+	@DisplayName("CreateHealthReportCommand를 통해 HealthReport를 생성할 수 있다.")
+	void createHealthReport() {
+		// given
+		CreateHealthReportCommand command = new CreateHealthReportCommand(
+				1L, LocalDate.of(2024, 1, 1), "Test Hospital",
+				170.0, 70.0, 85.0, 24.2, 120, 80,
+				15.0, 95.0, 190.0, 50.0, 120.0, 140.0,
+				1.0, 90.0, 25.0, 20.0, 30.0
+		);
+
+		// when
+		HealthReport healthReport = HealthReport.create(command, Gender.MALE);
+
+		// then
+		assertThat(healthReport.getMemberId()).isEqualTo(1L);
+		assertThat(healthReport.getGender()).isEqualTo(Gender.MALE);
+		assertThat(healthReport.getInstitutionName()).isEqualTo("Test Hospital");
+		assertThat(healthReport.getBmi().value()).isEqualTo(24.2);
+		assertThat(healthReport.getBloodPressure().systolicBp()).isEqualTo(120);
+	}
+
+	@Test
+	@DisplayName("UpdateHealthReportCommand를 통해 HealthReport를 수정할 수 있다.")
+	void updateHealthReport() {
+		// given
+		CreateHealthReportCommand createCommand = new CreateHealthReportCommand(
+				1L, LocalDate.of(2024, 1, 1), "Test Hospital",
+				170.0, 70.0, 85.0, 24.2, 120, 80,
+				15.0, 95.0, 190.0, 50.0, 120.0, 140.0,
+				1.0, 90.0, 25.0, 20.0, 30.0
+		);
+		HealthReport healthReport = HealthReport.create(createCommand, Gender.MALE);
+
+		UpdateHealthReportCommand updateCommand = new UpdateHealthReportCommand(
+				1L, 1L, LocalDate.of(2024, 2, 1), "New Hospital",
+				171.0, 71.0, 86.0, 24.5, 130, 85,
+				16.0, 100.0, 200.0, 55.0, 130.0, 150.0,
+				1.1, 85.0, 30.0, 25.0, 35.0
+		);
+
+		// when
+		healthReport.update(updateCommand);
+
+		// then
+		assertThat(healthReport.getHealthCheckDate()).isEqualTo(LocalDate.of(2024, 2, 1));
+		assertThat(healthReport.getInstitutionName()).isEqualTo("New Hospital");
+		assertThat(healthReport.getHeight().value()).isEqualTo(171.0);
+		assertThat(healthReport.getBloodPressure().systolicBp()).isEqualTo(130);
+	}
+
+	@Test
+	@DisplayName("HealthReport의 모든 상태 캐리어를 가져올 수 있다.")
+	void getStatusCarriers() {
+		// given
+		CreateHealthReportCommand command = new CreateHealthReportCommand(
+				1L, LocalDate.of(2024, 1, 1), "Test Hospital",
+				170.0, 70.0, 85.0, 24.2, 120, 80,
+				15.0, 95.0, 190.0, 50.0, 120.0, 140.0,
+				1.0, 90.0, 25.0, 20.0, 30.0
+		);
+		HealthReport healthReport = HealthReport.create(command, Gender.MALE);
+
+		// when
+		List<HealthStatusCarrier> carriers = healthReport.getStatusCarriers();
+
+		// then
+		assertThat(carriers).hasSize(14);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/score/calculator/HealthScoreCalculatorTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/score/calculator/HealthScoreCalculatorTest.java
@@ -1,0 +1,138 @@
+package org.sopt.carena.healthreport.domain.score.calculator;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.carena.healthreport.domain.HealthReport;
+import org.sopt.carena.healthreport.domain.score.HealthScore;
+import org.sopt.carena.member.domain.Gender;
+
+class HealthScoreCalculatorTest {
+
+	private final HealthScoreCalculator calculator = new HealthScoreCalculator();
+
+	@Test
+	@DisplayName("모든 지표가 정상 범위일 때 건강 점수는 100점이다.")
+	void calculatePerfectScore() {
+		// given
+		HealthReport report = HealthReport.builder()
+				.gender(Gender.MALE)
+				.height(170.0)
+				.weight(70.0)
+				.waistCircumference(85.0)
+				.bmi(22.0)
+				.systolicBloodPressure(110)
+				.diastolicBloodPressure(70)
+				.hemoglobin(14.0)
+				.fastingGlucose(90.0)
+				.serumCreatinine(1.0)
+				.egfr(90.0)
+				.ast(20.0)
+				.alt(20.0)
+				.gammaGtp(30.0)
+				.build();
+
+		// when
+		HealthScore healthScore = calculator.calculate(report);
+
+		// then
+		assertThat(healthScore.getValue()).isEqualTo(100L);
+	}
+
+	@Test
+	@DisplayName("일부 지표가 비정상일 때 가중치에 따라 점수가 감점된다.")
+	void calculateMixedScore() {
+		// given
+		// 공복혈당(가중치 0.2)이 1단계 이탈 (100.0) -> 점수 80
+		// 나머지는 정상 (점수 100)
+		HealthReport report = HealthReport.builder()
+				.gender(Gender.MALE)
+				.waistCircumference(85.0)
+				.bmi(22.0)
+				.systolicBloodPressure(110)
+				.diastolicBloodPressure(70)
+				.hemoglobin(14.0)
+				.fastingGlucose(100.0) // 1단계 이탈
+				.serumCreatinine(1.0)
+				.egfr(90.0)
+				.ast(20.0)
+				.alt(20.0)
+				.gammaGtp(30.0)
+				.build();
+
+		// when
+		HealthScore healthScore = calculator.calculate(report);
+
+		// then
+		// 가중치 합산: FastingGlucose(0.2*80) + Others(0.8*100) = 16 + 80 = 96
+		// BloodPressurePolicy 가중치: SYS_WEIGHT=0.12, DIA_WEIGHT=0.08 (둘 다 정상 100)
+		// ... 상세 계산은 Metric의 가중치 합에 따름
+		assertThat(healthScore.getValue()).isLessThan(100L);
+		assertThat(healthScore.getValue()).isGreaterThan(0L);
+	}
+
+	@Test
+	@DisplayName("데이터가 전혀 없을 때 건강 점수는 0점이다.")
+	void calculateEmptyScore() {
+		// given
+		HealthReport report = HealthReport.builder()
+				.gender(Gender.MALE)
+				.build();
+
+		// when
+		HealthScore healthScore = calculator.calculate(report);
+
+		// then
+		assertThat(healthScore.getValue()).isEqualTo(0L);
+	}
+
+	@Test
+	@DisplayName("동일한 수치라도 성별 기준에 따라 최종 건강 점수가 다를 수 있다.")
+	void calculateGenderDifference() {
+		// given
+		// 허리둘레 87.0은 남성에게는 정상(100점)이나 여성에게는 비정상(80점)
+		// 나머지는 모두 정상인 동일한 데이터
+		Double commonWaist = 87.0;
+
+		HealthReport maleReport = HealthReport.builder()
+				.gender(Gender.MALE)
+				.waistCircumference(commonWaist)
+				.bmi(22.0)
+				.systolicBloodPressure(110)
+				.diastolicBloodPressure(70)
+				.hemoglobin(14.0)
+				.fastingGlucose(90.0)
+				.serumCreatinine(1.0)
+				.egfr(90.0)
+				.ast(20.0)
+				.alt(20.0)
+				.gammaGtp(30.0)
+				.build();
+
+		HealthReport femaleReport = HealthReport.builder()
+				.gender(Gender.FEMALE)
+				.waistCircumference(commonWaist)
+				.bmi(22.0)
+				.systolicBloodPressure(110)
+				.diastolicBloodPressure(70)
+				.hemoglobin(13.0) // 여성에게 정상
+				.fastingGlucose(90.0)
+				.serumCreatinine(1.0)
+				.egfr(90.0)
+				.ast(20.0)
+				.alt(20.0)
+				.gammaGtp(20.0) // 여성에게 정상
+				.build();
+
+		// when
+		HealthScore maleScore = calculator.calculate(maleReport);
+		HealthScore femaleScore = calculator.calculate(femaleReport);
+
+		// then
+		// 남성은 허리둘레 87이 정상이므로 100점
+		assertThat(maleScore.getValue()).isEqualTo(100L);
+		// 여성은 허리둘레 87이 정상이 아니므로 100점보다 낮음
+		assertThat(femaleScore.getValue()).isLessThan(100L);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/score/metric/HealthMetricTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/score/metric/HealthMetricTest.java
@@ -1,0 +1,155 @@
+package org.sopt.carena.healthreport.domain.score.metric;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sopt.carena.healthreport.domain.score.ScoreItem;
+import org.sopt.carena.member.domain.Gender;
+
+class HealthMetricTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"22.0, MALE, 0, 100", // 정상
+			"25.0, MALE, 1, 80",  // 상방 이탈 (25.0 - 24.9 = 0.1, unit 5.0 -> step 1)
+			"18.4, MALE, 1, 80",  // 하방 이탈 (18.5 - 18.4 = 0.1, unit 5.0 -> step 1)
+			"35.0, MALE, 3, 40",  // 큰 이탈 (35.0 - 24.9 = 10.1, unit 5.0 -> step 3)
+			", MALE, 0, 100"      // null 케이스
+	})
+	@DisplayName("BMI 점수 계산이 정확하게 수행된다.")
+	void bmiScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.BMI.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"89.9, MALE, 0, 100",
+			"90.0, MALE, 1, 80",
+			"84.9, FEMALE, 0, 100",
+			"85.0, FEMALE, 1, 80",
+			"87.0, MALE, 0, 100",   // 남성 기준(90) 미달 -> 정상
+			"87.0, FEMALE, 1, 80",  // 여성 기준(85) 초과 -> 1단계 이탈
+			", MALE, 0, 100"        // null 케이스
+	})
+	@DisplayName("허리둘레 점수 계산이 성별에 따라 정확하게 수행된다.")
+	void waistScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.WAIST_CIRCUMFERENCE.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"13.0, MALE, 0, 100",
+			"12.9, MALE, 1, 80",
+			"12.0, FEMALE, 0, 100",
+			"11.9, FEMALE, 1, 80",
+			"12.5, MALE, 1, 80",    // 남성 기준(13.0) 미달 -> 1단계 이탈
+			"12.5, FEMALE, 0, 100", // 여성 기준(12.0) 충족 -> 정상
+			", MALE, 0, 100"        // null 케이스
+	})
+	@DisplayName("혈색소 점수 계산이 성별에 따라 정확하게 수행된다.")
+	void hemoglobinScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.HEMOGLOBIN.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"99.9, MALE, 0, 100",
+			"100.0, MALE, 1, 80", // upperExclusive=true 이므로 100.0 >= 100.0 에서 deviation 발생 (1e-9)
+			"124.9, MALE, 1, 80",
+			"125.0, MALE, 2, 60", // (25.0 + 1e-9) / 25.0 = 1.00000000004 -> step 2
+			"125.1, MALE, 2, 60",
+			", MALE, 0, 100"      // null 케이스
+	})
+	@DisplayName("공복혈당 점수 계산이 정확하게 수행된다.")
+	void fastingGlucoseScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.FASTING_GLUCOSE.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"1.5, MALE, 0, 100",
+			"1.6, MALE, 1, 80",
+			"1.79, MALE, 1, 80",
+			"1.8, MALE, 2, 60",  // (1.8 - 1.5) = 0.30000000000000004 -> step 2 (due to double precision)
+			"1.9, MALE, 2, 60",
+			", MALE, 0, 100"     // null 케이스
+	})
+	@DisplayName("혈청 크레아티닌 점수 계산이 정확하게 수행된다.")
+	void creatinineScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.SERUM_CREATININE.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"60.0, MALE, 0, 100",
+			"59.9, MALE, 1, 80",  // (60.0 - 59.9) / 15.0 = 0.006 -> step 1
+			"45.0, MALE, 1, 80",  // (60.0 - 45.0) / 15.0 = 1.0 -> step 1
+			"44.9, MALE, 2, 60",  // (60.0 - 44.9) / 15.0 = 1.006 -> step 2
+			", MALE, 0, 100"      // null 케이스
+	})
+	@DisplayName("신사구체여과율(eGFR) 점수 계산이 정확하게 수행된다.")
+	void egfrScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.EGFR.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"40.0, MALE, 0, 100",
+			"40.1, MALE, 1, 80",
+			"60.0, MALE, 1, 80",
+			"60.1, MALE, 2, 60",
+			", MALE, 0, 100"      // null 케이스
+	})
+	@DisplayName("AST 점수 계산이 정확하게 수행된다.")
+	void astScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.AST.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"35.0, MALE, 0, 100",
+			"35.1, MALE, 1, 80",
+			"55.0, MALE, 1, 80",
+			"55.1, MALE, 2, 60",
+			", MALE, 0, 100"      // null 케이스
+	})
+	@DisplayName("ALT 점수 계산이 정확하게 수행된다.")
+	void altScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.ALT.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"63.0, MALE, 0, 100",
+			"63.1, MALE, 1, 80",
+			"35.0, FEMALE, 0, 100",
+			"35.1, FEMALE, 1, 80",
+			"50.0, MALE, 0, 100",   // 남성 기준(63) 미달 -> 정상
+			"50.0, FEMALE, 1, 80",  // 여성 기준(35) 초과 -> 1단계 이탈
+			", MALE, 0, 100"        // null 케이스
+	})
+	@DisplayName("Gamma-GTP 점수 계산이 성별에 따라 정확하게 수행된다.")
+	void gammaGtpScore(Double value, Gender gender, int expectedStep, int expectedScore) {
+		ScoreItem result = HealthMetric.GAMMA_GTP.calculateResult(value, gender);
+		assertThat(result.getStep()).isEqualTo(expectedStep);
+		assertThat(result.getScore()).isEqualTo(expectedScore);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/anemia/HemoglobinStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/anemia/HemoglobinStatusTest.java
@@ -1,0 +1,33 @@
+package org.sopt.carena.healthreport.domain.status.anemia;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sopt.carena.member.domain.Gender;
+
+class HemoglobinStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"16.6, MALE, POLYCYTHEMIA_SUSPICIOUS",
+			"13.0, MALE, NORMAL",
+			"12.1, MALE, ANEMIA_BORDERLINE",
+			"12.0, MALE, ANEMIA_SUSPICIOUS",
+			"15.0, FEMALE, POLYCYTHEMIA_SUSPICIOUS",
+			"12.0, FEMALE, NORMAL",
+			"10.1, FEMALE, ANEMIA_BORDERLINE",
+			"10.0, FEMALE, ANEMIA_SUSPICIOUS",
+			", MALE, NONE",
+			", FEMALE, NONE"
+	})
+	@DisplayName("성별과 혈색소 수치에 따라 상태가 올바르게 판별된다.")
+	void of(Double value, Gender gender, HemoglobinStatus expected) {
+		// when
+		HemoglobinStatus status = HemoglobinStatus.of(value, gender);
+
+		// then
+		assertThat(status).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/diabetes/FastingGlucoseStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/diabetes/FastingGlucoseStatusTest.java
@@ -1,0 +1,28 @@
+package org.sopt.carena.healthreport.domain.status.diabetes;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class FastingGlucoseStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"0.0, NORMAL",
+			"99.9, NORMAL",
+			"100.0, IMPAIRED_FASTING_GLUCOSE",
+			"125.0, IMPAIRED_FASTING_GLUCOSE",
+			"125.1, DIABETES_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("공복 혈당 수치에 따라 상태가 올바르게 판별된다.")
+	void from(Double value, FastingGlucoseStatus expected) {
+		// when
+		FastingGlucoseStatus status = FastingGlucoseStatus.from(value);
+
+		// then
+		assertThat(status).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/dyslipidemia/DyslipidemiaStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/dyslipidemia/DyslipidemiaStatusTest.java
@@ -1,0 +1,62 @@
+package org.sopt.carena.healthreport.domain.status.dyslipidemia;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class DyslipidemiaStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"199.9, NORMAL",
+			"200.0, CHOLESTEROL_BORDERLINE",
+			"239.9, CHOLESTEROL_BORDERLINE",
+			"240.0, CHOLESTEROL_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("총 콜레스테롤 수치에 따라 상태가 올바르게 판별된다.")
+	void cholesterolStatus(Double value, CholesterolStatus expected) {
+		assertThat(CholesterolStatus.from(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"60.0, NORMAL",
+			"40.0, HDL_BORDERLINE",
+			"59.9, HDL_BORDERLINE",
+			"39.9, HDL_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("HDL 콜레스테롤 수치에 따라 상태가 올바르게 판별된다.")
+	void hdlStatus(Double value, HdlStatus expected) {
+		assertThat(HdlStatus.from(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"129.9, NORMAL",
+			"130.0, LDL_BORDERLINE",
+			"159.9, LDL_BORDERLINE",
+			"160.0, LDL_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("LDL 콜레스테롤 수치에 따라 상태가 올바르게 판별된다.")
+	void ldlStatus(Double value, LdlStatus expected) {
+		assertThat(LdlStatus.from(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"149.9, NORMAL",
+			"150.0, TRIGLYCERIDE_BORDERLINE",
+			"199.9, TRIGLYCERIDE_BORDERLINE",
+			"200.0, TRIGLYCERIDE_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("중성지방 수치에 따라 상태가 올바르게 판별된다.")
+	void triglycerideStatus(Double value, TriglycerideStatus expected) {
+		assertThat(TriglycerideStatus.from(value)).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/kidney/KidneyStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/kidney/KidneyStatusTest.java
@@ -1,0 +1,32 @@
+package org.sopt.carena.healthreport.domain.status.kidney;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class KidneyStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"60.0, EGFR_NORMAL",
+			"59.9, EGFR_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("eGFR 수치에 따라 상태가 올바르게 판별된다.")
+	void egfrStatus(Double value, EgfrStatus expected) {
+		assertThat(EgfrStatus.from(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"1.5, SERUM_CREATININE_NORMAL",
+			"1.6, SERUM_CREATININE_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("혈청 크레아티닌 수치에 따라 상태가 올바르게 판별된다.")
+	void serumCreatinineStatus(Double value, SerumCreatinineStatus expected) {
+		assertThat(SerumCreatinineStatus.from(value)).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/liver/LiverStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/liver/LiverStatusTest.java
@@ -1,0 +1,55 @@
+package org.sopt.carena.healthreport.domain.status.liver;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sopt.carena.member.domain.Gender;
+
+class LiverStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"40.0, NORMAL",
+			"40.1, AST_BORDERLINE",
+			"50.0, AST_BORDERLINE",
+			"50.1, AST_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("AST 수치에 따라 상태가 올바르게 판별된다.")
+	void astStatus(Double value, AstStatus expected) {
+		assertThat(AstStatus.from(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"35.0, NORMAL",
+			"35.1, ALT_BORDERLINE",
+			"45.0, ALT_BORDERLINE",
+			"45.1, ALT_SUSPICIOUS",
+			", NONE"
+	})
+	@DisplayName("ALT 수치에 따라 상태가 올바르게 판별된다.")
+	void altStatus(Double value, AltStatus expected) {
+		assertThat(AltStatus.from(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"63.0, MALE, NORMAL",
+			"63.1, MALE, GAMMA_GTP_BORDERLINE",
+			"77.0, MALE, GAMMA_GTP_BORDERLINE",
+			"77.1, MALE, GAMMA_GTP_SUSPICIOUS",
+			"35.0, FEMALE, NORMAL",
+			"35.1, FEMALE, GAMMA_GTP_BORDERLINE",
+			"45.0, FEMALE, GAMMA_GTP_BORDERLINE",
+			"45.1, FEMALE, GAMMA_GTP_SUSPICIOUS",
+			", MALE, NONE",
+			", FEMALE, NONE"
+	})
+	@DisplayName("성별과 Gamma-GTP 수치에 따라 상태가 올바르게 판별된다.")
+	void gammaGtpStatus(Double value, Gender gender, GammaGtpStatus expected) {
+		assertThat(GammaGtpStatus.of(value, gender)).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/BloodPressureStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/BloodPressureStatusTest.java
@@ -1,0 +1,64 @@
+package org.sopt.carena.healthreport.domain.status.measurement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class BloodPressureStatusTest {
+
+	@ParameterizedTest(name = "수축기 {0}, 이완기 {1} -> {2}")
+	@CsvSource({
+			"119, 79, NORMAL",
+			"120, 79, PRE_HYPERTENSION",
+			"119, 80, PRE_HYPERTENSION",
+			"139, 89, PRE_HYPERTENSION",
+			"140, 89, HYPERTENSION",
+			"139, 90, HYPERTENSION",
+			"140, 90, HYPERTENSION",
+			"140, , HYPERTENSION",
+			", 90, HYPERTENSION",
+			"120, , PRE_HYPERTENSION",
+			", 80, PRE_HYPERTENSION",
+			"119, , NORMAL",
+			", 79, NORMAL"
+	})
+	@DisplayName("수축기와 이완기 혈압 수치에 따라 상태가 올바르게 판별된다.")
+	void of(Integer systolic, Integer diastolic, BloodPressureStatus expected) {
+		// when
+		BloodPressureStatus status = BloodPressureStatus.of(systolic, diastolic);
+
+		// then
+		assertThat(status).isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("둘 다 null이면 NONE 상태를 반환한다.")
+	void ofNull() {
+		assertThat(BloodPressureStatus.of(null, null)).isEqualTo(BloodPressureStatus.NONE);
+	}
+
+	@ParameterizedTest(name = "수축기 {0} -> {1}")
+	@CsvSource({
+			"119, NORMAL",
+			"120, PRE_HYPERTENSION",
+			"140, HYPERTENSION"
+	})
+	@DisplayName("수축기 혈압만 있을 때 상태가 올바르게 판별된다.")
+	void ofSystolicBp(Integer systolic, BloodPressureStatus expected) {
+		assertThat(BloodPressureStatus.ofSystolicBp(systolic)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest(name = "이완기 {0} -> {1}")
+	@CsvSource({
+			"79, NORMAL",
+			"80, PRE_HYPERTENSION",
+			"90, HYPERTENSION"
+	})
+	@DisplayName("이완기 혈압만 있을 때 상태가 올바르게 판별된다.")
+	void ofDiastolicBp(Integer diastolic, BloodPressureStatus expected) {
+		assertThat(BloodPressureStatus.ofDiastolicBp(diastolic)).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/BmiStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/BmiStatusTest.java
@@ -1,0 +1,38 @@
+package org.sopt.carena.healthreport.domain.status.measurement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class BmiStatusTest {
+
+	@ParameterizedTest(name = "BMI {0} -> {1}")
+	@CsvSource({
+			"0.0, UNDERWEIGHT",
+			"18.4, UNDERWEIGHT",
+			"18.5, NORMAL",
+			"24.9, NORMAL",
+			"25.0, OVERWEIGHT",
+			"29.9, OVERWEIGHT",
+			"30.0, OBESE"
+	})
+	@DisplayName("BMI 수치에 따라 상태가 올바르게 판별된다.")
+	void from(Double value, BmiStatus expected) {
+		// when
+		BmiStatus status = BmiStatus.from(value);
+
+		// then
+		assertThat(status).isEqualTo(expected);
+	}
+
+	@DisplayName("BMI 수치가 null이면 NONE 상태를 반환한다.")
+	void fromNull() {
+		// when
+		BmiStatus status = BmiStatus.from(null);
+
+		// then
+		assertThat(status).isEqualTo(BmiStatus.NONE);
+	}
+}

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/BmiStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/BmiStatusTest.java
@@ -3,6 +3,7 @@ package org.sopt.carena.healthreport.domain.status.measurement;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -27,6 +28,7 @@ class BmiStatusTest {
 		assertThat(status).isEqualTo(expected);
 	}
 
+	@Test
 	@DisplayName("BMI 수치가 null이면 NONE 상태를 반환한다.")
 	void fromNull() {
 		// when

--- a/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/WaistCircumferenceStatusTest.java
+++ b/src/test/java/org/sopt/carena/healthreport/domain/status/measurement/WaistCircumferenceStatusTest.java
@@ -1,0 +1,41 @@
+package org.sopt.carena.healthreport.domain.status.measurement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sopt.carena.member.domain.Gender;
+
+class WaistCircumferenceStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"89.9, MALE, NORMAL",
+			"90.0, MALE, ABDOMINAL_OBESITY",
+			"84.9, FEMALE, NORMAL",
+			"85.0, FEMALE, ABDOMINAL_OBESITY"
+	})
+	@DisplayName("성별과 허리둘레 수치에 따라 상태가 올바르게 판별된다.")
+	void of(Double value, Gender gender, WaistCircumferenceStatus expected) {
+		// when
+		WaistCircumferenceStatus status = WaistCircumferenceStatus.of(value, gender);
+
+		// then
+		assertThat(status).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"MALE, NONE",
+			"FEMALE, NONE"
+	})
+	@DisplayName("허리둘레 수치가 null이면 NONE 상태를 반환한다.")
+	void ofNull(Gender gender, WaistCircumferenceStatus expected) {
+		// when
+		WaistCircumferenceStatus status = WaistCircumferenceStatus.of(null, gender);
+
+		// then
+		assertThat(status).isEqualTo(expected);
+	}
+}


### PR DESCRIPTION
## **🚀 Related issue**

closes #57 

## **#️⃣ Summary**

- 건강 검진 결과 도메인의 도메인 로직에 대한 테스트 코드를 작성합니다.

## **🎯 Work Description**

- [x] 검진 수치별 점수 산정 로직 테스트 작성
- [x] 검진 결과 전체 점수 산정 로직 테스트 작성
- [x] 각 항목별 검진 결과 자연어 변환 로직 테스트 작성
- [x] 요청 객체에서 도메인으로의 객체 변환 로직 테스트 작성
- [x] 도메인 내의 각 검진 수치별 캐리어 객체 반환 로직 테스트 작성

## **👍 동작 확인**

- 도메인 객체 변환 및 상태 캐리어 반환 로직 테스트 결과
  <img width="586" height="131" alt="스크린샷 2026-03-25 오후 6 16 46" src="https://github.com/user-attachments/assets/ad6bb657-8dd2-4187-b4bb-c3eeaa485b9e" />

- 전체 건강 점수
  <img width="588" height="155" alt="스크린샷 2026-03-25 오후 6 17 01" src="https://github.com/user-attachments/assets/ac77053f-6492-4903-9c21-71cde4c74219" />
 산정 로직 테스트 결과

- 검진 결과 수치별 점수 산정 로직 테스트 결과
  <img width="587" height="275" alt="스크린샷 2026-03-25 오후 6 17 26" src="https://github.com/user-attachments/assets/cb93982e-2c80-49f3-a6fb-f2c344c84072" />


## **💬 To Reviewers**

- 각 수치별로 자연어 변환을 위한 enum 변환 테스트는 많아서 사진 첨부를 생략했습니다...(테스트 통과 여부는 다 확인했습니다!)
- 도메인 로직 테스트에 필요한 데이터는 일단 `@CsvSource`를 이용하여 삽입되도록 구현해보았습니다.
- 추후에 더미 객체를 직접 선언하는 방식을 검토해보고 적용하는 것이 좋을 것 같다고 생각합니다.
- 테스트 과정에서 경계값 등에 대해 노션의 요구사항을 열심히 보긴 했지만 틀릴 수도 있을 것 같습니다... 리뷰하실 때 노션이나 화면설계서 등의 정보랑 대조하면서 다시 한 번 검토 부탁드립니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * 건강 리포트 생성/업데이트 동작 검증, 건강 점수 계산기(정상·혼합·빈값·성별 시나리오) 검증, 개별 지표(BMI, 허리둘레, 혈색소, 공복혈당, 크레아티닌·eGFR, AST/ALT/Gamma-GTP 등) 및 상태 분류(혈압, 이상지질, 간·신장·당뇨 등)에 대한 파라미터화된 경계·널 케이스 포함 포괄적 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->